### PR TITLE
feat: upgrade frontend to V3 smart contracts

### DIFF
--- a/contracts/Quest.json
+++ b/contracts/Quest.json
@@ -5,6 +5,16 @@
     "type": "constructor"
   },
   {
+    "inputs": [],
+    "name": "EnforcedPause",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ExpectedPause",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -32,6 +42,17 @@
     "type": "error"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "SafeERC20FailedOperation",
+    "type": "error"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {
@@ -50,12 +71,6 @@
         "indexed": false,
         "internalType": "string",
         "name": "ipfsProofCid",
-        "type": "string"
-      },
-      {
-        "indexed": false,
-        "internalType": "string",
-        "name": "socialHandle",
         "type": "string"
       }
     ],
@@ -99,6 +114,31 @@
       {
         "indexed": true,
         "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "FundsCredited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "previousOwner",
         "type": "address"
       },
@@ -110,6 +150,19 @@
       }
     ],
     "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
     "type": "event"
   },
   {
@@ -151,6 +204,12 @@
         "internalType": "string",
         "name": "title",
         "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
       },
       {
         "indexed": false,
@@ -205,24 +264,151 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "wallet",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "TokenAllowed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "TokenRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "questId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "verifier",
+        "type": "address"
+      }
+    ],
+    "name": "VerifierAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "questId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "verifier",
+        "type": "address"
+      }
+    ],
+    "name": "VerifierRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
         "type": "address"
       },
       {
         "indexed": false,
-        "internalType": "string",
-        "name": "xHandle",
-        "type": "string"
-      },
-      {
-        "indexed": false,
-        "internalType": "string",
-        "name": "email",
-        "type": "string"
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
       }
     ],
-    "name": "SocialAccountLinked",
+    "name": "Withdrawn",
     "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_questId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_verifier",
+        "type": "address"
+      }
+    ],
+    "name": "addVerifier",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "allowToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "allowedTokens",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   },
   {
     "inputs": [
@@ -268,6 +454,11 @@
         "internalType": "string",
         "name": "_requirements",
         "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
       }
     ],
     "name": "createQuest",
@@ -298,11 +489,6 @@
       {
         "internalType": "string",
         "name": "ipfsProofCid",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "socialHandle",
         "type": "string"
       },
       {
@@ -360,11 +546,6 @@
       {
         "internalType": "string",
         "name": "ipfsProofCid",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "socialHandle",
         "type": "string"
       },
       {
@@ -429,6 +610,11 @@
         "internalType": "string",
         "name": "description",
         "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
       },
       {
         "internalType": "uint256",
@@ -521,40 +707,6 @@
   {
     "inputs": [
       {
-        "internalType": "address",
-        "name": "_wallet",
-        "type": "address"
-      }
-    ],
-    "name": "getSocialAccount",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "xHandle",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "email",
-        "type": "string"
-      },
-      {
-        "internalType": "uint256",
-        "name": "linkedAt",
-        "type": "uint256"
-      },
-      {
-        "internalType": "bool",
-        "name": "verified",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "uint256",
         "name": "_questId",
         "type": "uint256"
@@ -611,24 +763,6 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "string",
-        "name": "_xHandle",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "_email",
-        "type": "string"
-      }
-    ],
-    "name": "linkSocialAccount",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
     "inputs": [],
     "name": "owner",
     "outputs": [
@@ -643,12 +777,104 @@
   },
   {
     "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      }
+    ],
+    "name": "pendingBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "pendingWithdrawals",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "questCounter",
     "outputs": [
       {
         "internalType": "uint256",
         "name": "",
         "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "questVerifiers",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
       }
     ],
     "stateMutability": "view",
@@ -678,6 +904,11 @@
         "internalType": "string",
         "name": "description",
         "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
       },
       {
         "internalType": "uint256",
@@ -729,8 +960,57 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_questId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_verifier",
+        "type": "address"
+      }
+    ],
+    "name": "removeVerifier",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reputationAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "rescueERC20",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -739,34 +1019,26 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "_token",
         "type": "address"
       }
     ],
-    "name": "socialAccounts",
-    "outputs": [
+    "name": "revokeToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
       {
-        "internalType": "string",
-        "name": "xHandle",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "email",
-        "type": "string"
-      },
-      {
-        "internalType": "uint256",
-        "name": "linkedAt",
-        "type": "uint256"
-      },
-      {
-        "internalType": "bool",
-        "name": "verified",
-        "type": "bool"
+        "internalType": "address",
+        "name": "_repAddress",
+        "type": "address"
       }
     ],
-    "stateMutability": "view",
+    "name": "setReputationAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -780,11 +1052,6 @@
         "internalType": "string",
         "name": "_ipfsProofCid",
         "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "_socialHandle",
-        "type": "string"
       }
     ],
     "name": "submitEntry",
@@ -796,11 +1063,37 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "totalEscrowed",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "newOwner",
         "type": "address"
       }
     ],
     "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpause",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -881,6 +1174,26 @@
       }
     ],
     "name": "verifyMultipleEntries",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdrawETH",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "withdrawToken",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/contracts/Quinty.json
+++ b/contracts/Quinty.json
@@ -5,6 +5,16 @@
     "type": "constructor"
   },
   {
+    "inputs": [],
+    "name": "EnforcedPause",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ExpectedPause",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -32,6 +42,17 @@
     "type": "error"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "SafeERC20FailedOperation",
+    "type": "error"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {
@@ -54,8 +75,14 @@
       },
       {
         "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
         "internalType": "uint256",
-        "name": "amount",
+        "name": "totalAmount",
         "type": "uint256"
       },
       {
@@ -123,18 +150,24 @@
     "inputs": [
       {
         "indexed": true,
-        "internalType": "uint256",
-        "name": "bountyId",
-        "type": "uint256"
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
       },
       {
         "indexed": false,
         "internalType": "uint256",
-        "name": "totalRefunded",
+        "name": "amount",
         "type": "uint256"
       }
     ],
-    "name": "DepositsRefunded",
+    "name": "FundsCredited",
     "type": "event"
   },
   {
@@ -160,25 +193,13 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": true,
+        "indexed": false,
         "internalType": "address",
-        "name": "wallet",
+        "name": "account",
         "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "string",
-        "name": "xHandle",
-        "type": "string"
-      },
-      {
-        "indexed": false,
-        "internalType": "string",
-        "name": "email",
-        "type": "string"
       }
     ],
-    "name": "SocialAccountLinked",
+    "name": "Paused",
     "type": "event"
   },
   {
@@ -210,12 +231,6 @@
       },
       {
         "indexed": false,
-        "internalType": "string",
-        "name": "socialHandle",
-        "type": "string"
-      },
-      {
-        "indexed": false,
         "internalType": "uint256",
         "name": "deposit",
         "type": "uint256"
@@ -229,30 +244,88 @@
     "inputs": [
       {
         "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "TokenAllowed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "TokenRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
         "internalType": "uint256",
         "name": "bountyId",
         "type": "uint256"
       },
       {
+        "indexed": false,
+        "internalType": "address[]",
+        "name": "winners",
+        "type": "address[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "submissionIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "WinnersSelected",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": true,
         "internalType": "address",
-        "name": "winner",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
         "type": "address"
       },
       {
         "indexed": false,
         "internalType": "uint256",
-        "name": "submissionId",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "reward",
+        "name": "amount",
         "type": "uint256"
       }
     ],
-    "name": "WinnerSelected",
+    "name": "Withdrawn",
     "type": "event"
   },
   {
@@ -263,6 +336,38 @@
         "internalType": "uint256",
         "name": "",
         "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "allowToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "allowedTokens",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
       }
     ],
     "stateMutability": "view",
@@ -294,8 +399,13 @@
         "type": "string"
       },
       {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
         "internalType": "uint256",
-        "name": "amount",
+        "name": "totalAmount",
         "type": "uint256"
       },
       {
@@ -317,16 +427,6 @@
         "internalType": "enum Quinty.BountyStatus",
         "name": "status",
         "type": "uint8"
-      },
-      {
-        "internalType": "address",
-        "name": "selectedWinner",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "selectedSubmissionId",
-        "type": "uint256"
       },
       {
         "internalType": "uint256",
@@ -376,6 +476,16 @@
         "internalType": "uint256",
         "name": "_slashPercent",
         "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_prizes",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
       }
     ],
     "name": "createBounty",
@@ -403,11 +513,6 @@
           {
             "internalType": "string",
             "name": "ipfsCid",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "socialHandle",
             "type": "string"
           },
           {
@@ -455,9 +560,19 @@
         "type": "string"
       },
       {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
         "internalType": "uint256",
-        "name": "amount",
+        "name": "totalAmount",
         "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "prizes",
+        "type": "uint256[]"
       },
       {
         "internalType": "uint256",
@@ -478,16 +593,6 @@
         "internalType": "enum Quinty.BountyStatus",
         "name": "status",
         "type": "uint8"
-      },
-      {
-        "internalType": "address",
-        "name": "selectedWinner",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "selectedSubmissionId",
-        "type": "uint256"
       },
       {
         "internalType": "uint256",
@@ -544,40 +649,6 @@
   {
     "inputs": [
       {
-        "internalType": "address",
-        "name": "_wallet",
-        "type": "address"
-      }
-    ],
-    "name": "getSocialAccount",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "xHandle",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "email",
-        "type": "string"
-      },
-      {
-        "internalType": "uint256",
-        "name": "linkedAt",
-        "type": "uint256"
-      },
-      {
-        "internalType": "bool",
-        "name": "verified",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "uint256",
         "name": "_bountyId",
         "type": "uint256"
@@ -598,11 +669,6 @@
       {
         "internalType": "string",
         "name": "ipfsCid",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "socialHandle",
         "type": "string"
       },
       {
@@ -689,24 +755,6 @@
   {
     "inputs": [
       {
-        "internalType": "string",
-        "name": "_xHandle",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "_email",
-        "type": "string"
-      }
-    ],
-    "name": "linkSocialAccount",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "uint256",
         "name": "_bountyId",
         "type": "uint256"
@@ -725,6 +773,74 @@
         "internalType": "address",
         "name": "",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      }
+    ],
+    "name": "pendingBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "pendingWithdrawals",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -766,17 +882,48 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "rescueERC20",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "revokeToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "_bountyId",
         "type": "uint256"
       },
       {
-        "internalType": "uint256",
-        "name": "_submissionId",
-        "type": "uint256"
+        "internalType": "uint256[]",
+        "name": "_submissionIds",
+        "type": "uint256[]"
       }
     ],
-    "name": "selectWinner",
+    "name": "selectWinners",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -797,40 +944,6 @@
   {
     "inputs": [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "name": "socialAccounts",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "xHandle",
-        "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "email",
-        "type": "string"
-      },
-      {
-        "internalType": "uint256",
-        "name": "linkedAt",
-        "type": "uint256"
-      },
-      {
-        "internalType": "bool",
-        "name": "verified",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "uint256",
         "name": "_bountyId",
         "type": "uint256"
@@ -839,16 +952,30 @@
         "internalType": "string",
         "name": "_ipfsCid",
         "type": "string"
-      },
-      {
-        "internalType": "string",
-        "name": "_socialHandle",
-        "type": "string"
       }
     ],
     "name": "submitToBounty",
     "outputs": [],
     "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "totalEscrowed",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -873,6 +1000,33 @@
       }
     ],
     "name": "triggerSlash",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdrawETH",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "withdrawToken",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/contracts/QuintyReputation.json
+++ b/contracts/QuintyReputation.json
@@ -233,6 +233,32 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "CallerAuthorized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "caller",
+        "type": "address"
+      }
+    ],
+    "name": "CallerRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": false,
         "internalType": "uint256",
         "name": "_tokenId",
@@ -383,6 +409,38 @@
     "name": "approve",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_caller",
+        "type": "address"
+      }
+    ],
+    "name": "authorizeCaller",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "authorizedCallers",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -693,6 +751,19 @@
   {
     "inputs": [],
     "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_caller",
+        "type": "address"
+      }
+    ],
+    "name": "revokeCaller",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/docs/brainstorms/2026-02-25-frontend-v3-contract-upgrade-brainstorm.md
+++ b/docs/brainstorms/2026-02-25-frontend-v3-contract-upgrade-brainstorm.md
@@ -1,0 +1,113 @@
+---
+topic: Frontend V3 Contract Upgrade
+date: 2026-02-25
+status: complete
+---
+
+# Frontend V3 Contract Upgrade Brainstorm
+
+## Context
+
+The smart contract system (sc-quinty) has been upgraded to V3 with major changes:
+
+- **Multi-winner bounties** — Up to 10 ranked prize tiers
+- **ERC-20 token support** — ETH + whitelisted tokens (USDC on Base Sepolia)
+- **Pull-based withdrawals** — All payouts credited to pendingWithdrawals mapping, users pull via withdrawETH()/withdrawToken()
+- **Delegated verifiers** — Quest creators can delegate verification to other addresses
+- **Removed social accounts** — socialHandle removed from submitToBounty() and submitEntry()
+- **Pausable** — Emergency pause on all state-changing functions
+- **rescueERC20** — Owner can rescue accidentally sent tokens
+
+The frontend (fe-quinty) needs a full update to match the new contract API and expose new features.
+
+## What We're Building
+
+A comprehensive frontend update that:
+
+1. **Replaces all contract ABIs** with V3 versions and updates contract addresses
+2. **Updates all contract call signatures** — remove socialHandle, add token param, use new selectWinners (plural)
+3. **Adds multi-winner prize creation** — simple split UI (total + winner count → auto-calculated tiers)
+4. **Adds ERC-20 token selection** — ETH + USDC dropdown in bounty/quest creation forms
+5. **Adds global withdrawal banner** — persistent header badge showing pending balance, one-click withdraw
+6. **Adds drag-to-rank winner selection** — visual ranked slot interface for multi-winner judging
+7. **Adds delegated verifier management** — address input + add/remove on quest detail page
+8. **Removes social handle fields** from all submission forms
+
+## Key Decisions
+
+### 1. Prize tier UX: Simple split with auto-calculation
+Creator enters total amount + number of winners. System calculates split (e.g., 50/30/20 for 3 winners, equal split for custom). This covers the majority of use cases without complex form UI. The contract accepts any prizes[] array, so we can always add advanced manual entry later.
+
+### 2. Token selection: ETH + USDC only
+Hardcoded dropdown with two options. No dynamic whitelist query needed. Matches current contract whitelist. When more tokens are whitelisted, add them to the dropdown. YAGNI — don't build dynamic token resolution until there are more than 3-4 tokens.
+
+### 3. Withdrawal UX: Global banner in header
+Persistent banner/badge in the site header whenever the user has a pending balance > 0. Shows amounts per token. One-click withdraw per token type. This is discoverable, non-intrusive, and keeps withdrawal as a global concern rather than per-bounty. Need to poll/watch pendingBalance(ETH, user) and pendingBalance(USDC, user) on the connected wallet.
+
+### 4. Winner selection: Drag-to-rank
+Bounty detail page shows submission cards that can be dragged into ranked prize slots (1st, 2nd, 3rd...). Number of slots matches prizes.length from bounty creation. Visual, intuitive, prevents errors (can't select more winners than prize tiers). May use a lightweight drag library or native HTML drag-and-drop.
+
+### 5. Delegated verifiers: Include in this update
+Quest detail page gets an "Add Verifier" section visible to the quest creator. Simple address input with add/remove functionality. Small scope but useful feature.
+
+### 6. Scope: Full parity in one update
+Update everything at once rather than phased. The contract changes are breaking (new function signatures), so we need to update ABIs and calls anyway. Adding the UI enhancements alongside is incremental work on top of the mandatory changes.
+
+## What We're NOT Building
+
+- Dynamic token whitelist resolution (querying allowedTokens)
+- Advanced manual prize tier entry (per-rank custom amounts)
+- Batch withdrawal (withdraw all tokens at once)
+- Pause indicator in UI (admin-only concern)
+- Token approval flow UI (approve + create in one step — just handle it in the create flow)
+
+## Affected Files (High-Level)
+
+### Contract Layer
+- `/contracts/*.json` — Replace all ABI files with V3 versions from sc-quinty/exported-abis/
+- `/src/utils/contracts.ts` — Update addresses, add USDC constants, update type exports
+
+### Hooks
+- `/src/hooks/useBounties.ts` — Update read calls for new getBounty return shape (token, prizes[], totalAmount)
+- `/src/hooks/useQuests.ts` — Update read calls for new getQuest return shape (token field)
+- New: `/src/hooks/useWithdrawals.ts` — Poll pending balances, provide withdraw functions
+
+### Forms
+- `/src/components/bounties/BountyForm.tsx` — Add winner count + token selector, remove social handle references, calculate prizes array
+- `/src/components/quests/QuestForm.tsx` — Add token selector, remove social handle references
+
+### Detail Pages
+- `/src/app/bounties/[id]/page.tsx` — Multi-winner display, drag-to-rank judging, show token type
+- `/src/app/quests/[id]/page.tsx` — Delegated verifier management, show token type
+
+### New Components
+- Withdrawal banner component (in Header)
+- Drag-to-rank winner selector component
+- Token selector dropdown component (shared)
+- Verifier management component
+
+### Removals
+- Social handle input fields from all submission forms
+- Social handle display from submission cards
+- SocialAccount-related code/references
+
+## ERC-20 Approval Flow
+
+For ERC-20 bounties/quests, the user needs to approve the contract to spend their tokens before creation. The UX should be:
+
+1. User selects USDC as token, enters amount
+2. On "Create", check allowance first
+3. If insufficient allowance: show "Approve USDC" button → wait for tx → then auto-proceed to create
+4. If already approved: proceed directly to create
+
+This is a standard pattern — two-step for first-time, one-step after approval.
+
+## Resolved Questions
+
+1. **How to handle old bounties/quests created with V2 API?** — The contract was redeployed with new addresses. Old bounties are on old contracts. The frontend just points to new addresses — no backward compatibility needed.
+2. **Should we show token logos?** — Yes, use simple ETH and USDC SVG icons inline with the amount display.
+3. **Split percentages for auto-calculation?** — Use: 1 winner = 100%, 2 winners = 60/40, 3 winners = 50/30/20, 4+ = proportional decrease with minimum 5% for last place.
+
+## Open Questions
+
+None — all questions resolved during brainstorming.

--- a/docs/plans/2026-02-25-feat-frontend-v3-contract-upgrade-plan.md
+++ b/docs/plans/2026-02-25-feat-frontend-v3-contract-upgrade-plan.md
@@ -1,0 +1,299 @@
+---
+title: "feat: Frontend V3 Contract Upgrade"
+type: feat
+status: active
+date: 2026-02-25
+origin: docs/brainstorms/2026-02-25-frontend-v3-contract-upgrade-brainstorm.md
+---
+
+# feat: Frontend V3 Contract Upgrade
+
+## Overview
+
+Comprehensive frontend update to match the sc-quinty V3 smart contract API. This includes replacing all ABIs, updating contract call signatures, adding multi-winner prize creation, ERC-20 token selection (ETH + USDC), a global withdrawal banner, drag-to-rank winner selection, delegated verifier management, and removing all social handle fields.
+
+## Problem Statement / Motivation
+
+The smart contract system (sc-quinty) has been upgraded to V3 with breaking changes:
+- New function signatures (removed socialHandle, added token param, selectWinner→selectWinners)
+- New features (multi-winner bounties, ERC-20 support, pull-based withdrawals, delegated verifiers)
+- New contract addresses (redeployed)
+
+The frontend is currently non-functional against V3 contracts. This update restores full functionality and exposes all new features.
+
+## Proposed Solution
+
+Full parity update in one pass (see brainstorm: docs/brainstorms/2026-02-25-frontend-v3-contract-upgrade-brainstorm.md). Key UX decisions:
+- **Prize tiers**: Simple split with auto-calculation (total + winner count)
+- **Token selection**: Hardcoded ETH + USDC dropdown
+- **Withdrawal**: Global banner in header with per-token withdraw
+- **Winner selection**: Drag-to-rank visual interface
+- **Delegated verifiers**: Address input + add/remove on quest detail page
+
+## Technical Approach
+
+### Phase 1: Contract Layer (Foundation)
+
+All other changes depend on correct ABIs and addresses.
+
+- [ ] Copy V3 ABI files from `sc-quinty/exported-abis/` to `fe-quinty/contracts/`
+  - `Quinty.json` — Bounty contract ABI
+  - `Quest.json` — Quest contract ABI
+  - `QuintyReputation.json` — Reputation ABI (if used)
+  - Files: `/contracts/Quinty.json`, `/contracts/Quest.json`
+
+- [ ] Update `/src/utils/contracts.ts`
+  - Update Quinty and Quest contract addresses to V3 deployed addresses
+  - Add `USDC_BASE_SEPOLIA` constant (`0x036CbD53842c5426634e7929541eC2318f3dCF7e`)
+  - Add `ETH_ADDRESS` constant (`0x0000000000000000000000000000000000000000`)
+  - Remove AirdropBounty import if present
+  - Update ABI imports to match new file names
+
+### Phase 2: Type Updates & Hook Refactoring
+
+Update all TypeScript interfaces and data-fetching hooks to match V3 return shapes.
+
+- [ ] Update `/src/hooks/useBounties.ts`
+  - Remove `socialHandle` from `Submission` interface (was at line 10)
+  - Add `token: string` and `prizes: bigint[]` to `Bounty` interface (lines 15-31)
+  - Add `totalAmount: bigint` to `Bounty` interface
+  - Update `getBounty` positional destructuring to match V3 return shape (lines 78-93)
+  - Update `WinnerSelected` event to `WinnersSelected` (line 137)
+  - Update any `selectWinner` references to `selectWinners`
+
+- [ ] Update `/src/hooks/useQuests.ts`
+  - Remove `socialHandle` from `Entry` interface (line 29)
+  - Add `token: string` to `Quest` interface (lines 8-24)
+  - Update `getQuest` positional destructuring to match V2 return shape (lines 68-81)
+
+- [ ] Create `/src/hooks/useWithdrawals.ts` (NEW)
+  - Poll `pendingBalance(ETH_ADDRESS, userAddress)` on Quinty contract
+  - Poll `pendingBalance(USDC_BASE_SEPOLIA, userAddress)` on Quinty contract
+  - Poll same on Quest contract
+  - Aggregate totals across both contracts
+  - Provide `withdrawETH()` and `withdrawToken(tokenAddr)` functions for each contract
+  - Use `useReadContract` + `useWriteContract` from Wagmi
+  - Refresh balances on block or after withdrawal tx confirmation
+
+### Phase 3: Shared Components (New)
+
+Build reusable components needed by multiple features.
+
+- [ ] Create `/src/components/ui/TokenSelector.tsx` (NEW)
+  - Dropdown with two options: ETH (default) and USDC
+  - Show token icon (simple SVG) + name
+  - Props: `value`, `onChange`, `disabled`
+  - Uses shadcn/ui Select component
+  - Returns token address (ETH_ADDRESS or USDC_BASE_SEPOLIA)
+
+- [ ] Create `/src/components/WithdrawalBanner.tsx` (NEW)
+  - Uses `useWithdrawals` hook
+  - Shows persistent banner/badge in header when any pending balance > 0
+  - Displays amounts per token (e.g., "0.5 ETH • 100 USDC available to withdraw")
+  - One-click withdraw button per token type
+  - Loading states during withdrawal transactions
+  - Auto-hides when all balances are 0
+
+- [ ] Create `/src/components/bounties/DragToRank.tsx` (NEW)
+  - Visual ranked slot interface (1st, 2nd, 3rd... slots)
+  - Number of slots = `prizes.length` from bounty creation
+  - Submission cards can be dragged into slots
+  - Show prize amount per slot
+  - Validate: can't select more winners than prize tiers
+  - Handle edge case: fewer submissions than prize slots (some slots stay empty)
+  - Returns ordered array of submission IDs for `selectWinners()`
+  - Use native HTML5 drag-and-drop or lightweight library (dnd-kit if already in deps, otherwise native)
+
+- [ ] Create `/src/components/quests/VerifierManagement.tsx` (NEW)
+  - Visible only to quest creator
+  - Address input field + "Add Verifier" button
+  - List of current verifiers with "Remove" button each
+  - Calls `addVerifier(questId, address)` and `removeVerifier(questId, address)`
+  - Basic address validation (0x + 40 hex chars)
+  - Uses `useWriteContract` from Wagmi
+
+### Phase 4: Form Updates
+
+Update creation forms to support new features.
+
+- [ ] Update `/src/components/bounties/BountyForm.tsx`
+  - Add TokenSelector component (ETH default)
+  - Add "Number of Winners" input (1-10, default 1)
+  - Auto-calculate prize split based on winner count and total amount:
+    - 1 winner = 100%
+    - 2 winners = 60/40
+    - 3 winners = 50/30/20
+    - 4+ winners = proportional decrease, minimum 5% for last place
+  - Display calculated prize breakdown preview
+  - For ERC-20: implement approve-then-create flow
+    1. Check `allowance` first
+    2. If insufficient: show "Approve USDC" button → wait for tx
+    3. Then auto-proceed to `createBounty`
+  - Update `createBounty` call: add `prizes[]` array and `token` address parameter
+  - Remove any social handle references from submission section
+  - For ETH: `{ value: totalAmount }` as before
+  - For ERC-20: no `msg.value`, contract pulls via `safeTransferFrom`
+
+- [ ] Update `/src/components/quests/QuestForm.tsx`
+  - Add TokenSelector component (ETH default)
+  - For ERC-20: implement approve-then-create flow (same pattern as bounty)
+  - Update `createQuest` call: add `token` address parameter
+  - For ETH: `{ value: perQualifier * maxQualifiers }`
+  - For ERC-20: no `msg.value`
+  - Remove any social handle references
+
+### Phase 5: Detail Page Updates
+
+Update bounty and quest detail pages for new features.
+
+- [ ] Update `/src/app/bounties/[id]/page.tsx`
+  - Update `Bounty` and `Submission` interfaces to match V3 (remove socialHandle, add token/prizes/totalAmount)
+  - Display token type with icon next to amounts (ETH icon or USDC icon)
+  - Display prize tier breakdown (1st: X, 2nd: Y, 3rd: Z)
+  - Replace single-winner selection with DragToRank component for multi-winner
+  - Update `submitToBounty` call: remove socialHandle param
+  - For ERC-20 submissions: implement approve-then-submit for 1% deposit
+  - Update `selectWinner` → `selectWinners(bountyId, submissionIds[])` — takes array from DragToRank
+  - Remove socialHandle display from submission cards (lines 727-734)
+  - Show "Fewer winners than slots" messaging when applicable
+
+- [ ] Update `/src/app/quests/[id]/page.tsx`
+  - Update `Entry` and `Quest` interfaces (remove socialHandle, add token)
+  - Display token type with icon next to reward amounts
+  - Update `submitEntry` call: remove socialHandle param
+  - Remove socialHandle display from entry cards (lines 646-654)
+  - Add VerifierManagement component (visible only to quest creator)
+  - Show delegated verifier badge on verification actions
+
+### Phase 6: Header & Withdrawal Integration
+
+- [ ] Update `/src/components/Header.tsx`
+  - Import and render WithdrawalBanner component
+  - Position between nav and profile section (around line 81-82)
+  - Only render when wallet is connected
+
+### Phase 7: Contract Manager Updates
+
+Update the manager components that orchestrate contract interactions.
+
+- [ ] Update `/src/components/BountyManager.tsx`
+  - Update `createBounty` args (lines 87-99): add `prizes[]` and `token` params
+  - Update `submitToBounty` (lines 107-130): remove socialHandle, handle ERC-20 deposit approval
+  - Update `selectWinner` → `selectWinners` (lines 132-139): accept array of submission IDs
+
+- [ ] Update `/src/components/QuestManager.tsx`
+  - Update `createQuest` args (lines 67-80): add `token` param
+  - Handle ERC-20 approval flow before creation
+  - Remove socialHandle from quest submission calls
+
+### Phase 8: Cleanup & Polish
+
+- [ ] Remove all socialHandle/SocialAccount references
+  - Search codebase for `socialHandle`, `social_handle`, `SocialAccount`
+  - Remove from interfaces, form fields, display components, and any utility functions
+  - Verify no dead imports or unused types remain
+
+- [ ] Add token icons
+  - Create or import simple ETH and USDC SVG icons
+  - Use inline with amount displays throughout bounty/quest cards and detail pages
+
+- [ ] Test all flows end-to-end
+  - ETH bounty creation (single winner)
+  - ETH bounty creation (multi-winner)
+  - USDC bounty creation (approve + create flow)
+  - Bounty submission (ETH deposit)
+  - Bounty submission (USDC deposit with approval)
+  - Multi-winner selection via drag-to-rank
+  - ETH quest creation
+  - USDC quest creation (approve + create)
+  - Quest entry submission
+  - Quest verification (by creator)
+  - Quest verification (by delegated verifier)
+  - Add/remove delegated verifier
+  - Withdrawal of pending ETH
+  - Withdrawal of pending USDC
+  - Withdrawal banner appears/disappears correctly
+
+## ERC-20 Approval Flow (Detail)
+
+Standard two-step pattern used in BountyForm, QuestForm, and bounty submission:
+
+```typescript
+// 1. Check current allowance
+const allowance = await tokenContract.read.allowance([userAddress, contractAddress]);
+
+// 2. If insufficient, request approval
+if (allowance < requiredAmount) {
+  const approveTx = await tokenContract.write.approve([contractAddress, requiredAmount]);
+  await waitForTransactionReceipt({ hash: approveTx });
+}
+
+// 3. Proceed with creation/submission (no msg.value for ERC-20)
+const createTx = await bountyContract.write.createBounty([...args]);
+```
+
+**UX states:** "Approve USDC" button → spinner → "Creating Bounty" → success
+
+## Prize Split Auto-Calculation
+
+```typescript
+function calculatePrizeSplit(totalAmount: bigint, winnerCount: number): bigint[] {
+  if (winnerCount === 1) return [totalAmount];
+  if (winnerCount === 2) return [totalAmount * 60n / 100n, totalAmount * 40n / 100n];
+  if (winnerCount === 3) return [totalAmount * 50n / 100n, totalAmount * 30n / 100n, totalAmount * 20n / 100n];
+  // 4+ winners: proportional with minimum 5% for last
+  // ... implementation detail
+}
+```
+
+## What We're NOT Building
+
+(See brainstorm: docs/brainstorms/2026-02-25-frontend-v3-contract-upgrade-brainstorm.md)
+
+- Dynamic token whitelist resolution (querying allowedTokens)
+- Advanced manual prize tier entry (per-rank custom amounts)
+- Batch withdrawal (withdraw all tokens at once)
+- Pause indicator in UI (admin-only concern)
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [ ] All contract ABIs updated to V3 versions
+- [ ] All contract addresses point to V3 deployments
+- [ ] Bounty creation supports ETH and USDC with token selector
+- [ ] Bounty creation supports 1-10 winners with auto-calculated prize split
+- [ ] Quest creation supports ETH and USDC with token selector
+- [ ] ERC-20 flows handle approval step before creation/submission
+- [ ] Multi-winner selection uses drag-to-rank interface
+- [ ] Withdrawal banner shows pending balances and enables one-click withdraw
+- [ ] Delegated verifiers can be added/removed on quest detail page
+- [ ] All socialHandle fields removed from forms and displays
+- [ ] Token type displayed with icon on all amount displays
+
+### Non-Functional Requirements
+
+- [ ] No TypeScript compilation errors
+- [ ] All existing functionality preserved (no regressions)
+- [ ] ERC-20 approval UX is clear (loading states, error messages)
+- [ ] Drag-to-rank is usable on mobile (touch events)
+
+## Dependencies
+
+- V3 contract ABIs from `sc-quinty/exported-abis/`
+- V3 contract addresses (from deployment — currently partially deployed, will use latest addresses)
+- USDC contract address on Base Sepolia: `0x036CbD53842c5426634e7929541eC2318f3dCF7e`
+
+## Sources & References
+
+### Origin
+
+- **Brainstorm document:** [docs/brainstorms/2026-02-25-frontend-v3-contract-upgrade-brainstorm.md](docs/brainstorms/2026-02-25-frontend-v3-contract-upgrade-brainstorm.md) — Key decisions: simple split prizes, ETH+USDC dropdown, global withdrawal banner, drag-to-rank winners, include verifier UI, full parity scope
+
+### Internal References
+
+- Contract API: `sc-quinty/CLAUDE.md` — full V3 function signatures and integration patterns
+- Exported ABIs: `sc-quinty/exported-abis/` — Quinty.json, Quest.json, constants.ts
+- Existing hooks pattern: `src/hooks/useBounties.ts`, `src/hooks/useQuests.ts`
+- Existing form pattern: `src/components/bounties/BountyForm.tsx`
+- Header component: `src/components/Header.tsx`

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -441,7 +441,7 @@ export default function ProfilePage() {
                                                     <div className="mt-auto pt-3 border-t border-zinc-100 flex items-end justify-between">
                                                         <div>
                                                             <div className="flex items-baseline gap-1">
-                                                                <span className="text-lg font-bold text-zinc-900 tabular-nums tracking-tight">{formatETH(bounty.amount)}</span>
+                                                                <span className="text-lg font-bold text-zinc-900 tabular-nums tracking-tight">{formatETH(bounty.totalAmount)}</span>
                                                                 <span className="text-[10px] font-mono font-semibold text-zinc-400">ETH</span>
                                                             </div>
                                                         </div>

--- a/src/components/BountyCard.tsx
+++ b/src/components/BountyCard.tsx
@@ -4,7 +4,7 @@ import { useAccount } from "wagmi";
 import { formatETH, formatTimeLeft, formatAddress } from "../utils/web3";
 import { fetchMetadataFromIpfs, BountyMetadata } from "../utils/ipfs";
 import { getEthPriceInUSD, convertEthToUSD, formatUSD } from "../utils/prices";
-import { BountyStatus } from "../utils/contracts";
+import { BountyStatus, getTokenInfo, formatTokenAmount } from "../utils/contracts";
 import { Clock, Users, AlertTriangle, Gavel, ArrowUpRight } from "lucide-react";
 import { useWalletName } from "@/hooks/useWalletName";
 import { BountyQuickView } from "./bounties/BountyQuickView";
@@ -12,7 +12,7 @@ import { Bounty } from "../hooks/useBounties";
 
 interface BountyCardProps {
   bounty: Bounty;
-  onSubmitToBounty: (bountyId: number, ipfsCid: string, socialHandle: string) => void;
+  onSubmitToBounty: (bountyId: number, ipfsCid: string) => void;
   onSelectWinner: (bountyId: number, submissionId: number) => void;
   onTriggerSlash: (bountyId: number) => void;
   onRefundNoSubmissions: (bountyId: number) => void;
@@ -60,6 +60,7 @@ export default function BountyCard({ bounty, onTriggerSlash }: BountyCardProps) 
   const config = phaseConfig[phase] || phaseConfig.OPEN;
   const creatorName = useWalletName(bounty.creator);
   const canSlash = phase === "SLASH_PENDING" && bounty.submissionCount > 0;
+  const tokenInfo = getTokenInfo(bounty.token);
   const title = metadata?.title || bounty.title || bounty.description.split("\n")[0];
   const imageUrl = metadata?.images?.[0]
     ? `https://purple-elderly-silverfish-382.mypinata.cloud/ipfs/${metadata.images[0]}`
@@ -136,12 +137,12 @@ export default function BountyCard({ bounty, onTriggerSlash }: BountyCardProps) 
             {/* Reward */}
             <div>
               <div className="flex items-baseline gap-1">
-                <span className="text-lg font-bold text-zinc-900 tabular-nums tracking-tight">{formatETH(bounty.amount)}</span>
-                <span className="text-[10px] font-mono font-semibold text-zinc-400">ETH</span>
+                <span className="text-lg font-bold text-zinc-900 tabular-nums tracking-tight">{formatTokenAmount(bounty.totalAmount, bounty.token)}</span>
+                <span className="text-[10px] font-mono font-semibold text-zinc-400">{tokenInfo.symbol}</span>
               </div>
-              {ethPrice > 0 && (
+              {ethPrice > 0 && tokenInfo.symbol === "ETH" && (
                 <span className="text-[10px] font-mono text-zinc-300 tabular-nums">
-                  {formatUSD(convertEthToUSD(Number(bounty.amount) / 1e18, ethPrice))}
+                  {formatUSD(convertEthToUSD(Number(bounty.totalAmount) / 1e18, ethPrice))}
                 </span>
               )}
             </div>

--- a/src/components/BountyManager.tsx
+++ b/src/components/BountyManager.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo, useEffect } from "react";
 import { useAccount, useWriteContract, useWaitForTransactionReceipt, useReadContract } from "wagmi";
 import { readContract } from "@wagmi/core";
-import { CONTRACT_ADDRESSES, QUINTY_ABI, BASE_SEPOLIA_CHAIN_ID, BountyStatus } from "../utils/contracts";
+import { CONTRACT_ADDRESSES, QUINTY_ABI, BASE_SEPOLIA_CHAIN_ID, BountyStatus, ETH_ADDRESS, ERC20_ABI, calculatePrizeSplit, parseTokenAmount, getTokenInfo } from "../utils/contracts";
 import { parseETH, wagmiConfig } from "../utils/web3";
 import { uploadMetadataToIpfs, BountyMetadata } from "../utils/ipfs";
 import BountyCard from "./BountyCard";
@@ -26,11 +26,9 @@ export default function BountyManager() {
   const filteredBounties = useMemo(() => {
     return bounties.filter(b => {
       const now = BigInt(Math.floor(Date.now() / 1000));
-      // Active: OPEN or JUDGING phase
       const isActive = b.status === BountyStatus.OPEN || b.status === BountyStatus.JUDGING;
-      // Past: RESOLVED or SLASHED
       const isPast = b.status === BountyStatus.RESOLVED || b.status === BountyStatus.SLASHED;
-      
+
       if (statusFilter === "resolved") return b.status === BountyStatus.RESOLVED;
       if (statusFilter === "slashed") return b.status === BountyStatus.SLASHED;
       if (statusFilter === "judging") return b.status === BountyStatus.JUDGING || (b.status === BountyStatus.OPEN && now > b.openDeadline);
@@ -44,8 +42,6 @@ export default function BountyManager() {
 
   const handleCreateBounty = async (formData: any) => {
     try {
-      console.log("Creating bounty with form data:", formData);
-
       if (!address) {
         alert("Please connect your wallet first");
         return;
@@ -73,30 +69,75 @@ export default function BountyManager() {
         deliverables: formData.deliverables.filter((d: string) => d.trim()),
         skills: formData.skills.filter((s: string) => s.trim()),
         images: formData.images || [],
-        deadline: judgingDeadlineTs, // Use judging deadline as primary deadline for metadata
+        deadline: judgingDeadlineTs,
         bountyType: formData.bountyType,
       };
 
-      console.log("Uploading metadata to IPFS...");
       const metadataCid = await uploadMetadataToIpfs(metadata);
-      console.log("Metadata CID:", metadataCid);
 
-      console.log("Calling smart contract with new params...");
-      console.log("openDeadline:", openDeadlineTs, "judgingDeadline:", judgingDeadlineTs, "slashPercent:", formData.slashPercent);
-      
-      writeContract({
-        address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quinty as `0x${string}`,
-        abi: QUINTY_ABI,
-        functionName: "createBounty",
-        args: [
-          formData.title,
-          `${formData.description}\n\nMetadata: ipfs://${metadataCid}`,
-          BigInt(openDeadlineTs),
-          BigInt(judgingDeadlineTs),
-          BigInt(formData.slashPercent), // Already in basis points from form
-        ],
-        value: parseETH(formData.amount),
-      });
+      const token = formData.token || ETH_ADDRESS;
+      const tokenInfo = getTokenInfo(token);
+      const totalAmount = parseTokenAmount(formData.amount, token);
+      const winnerCount = formData.winnerCount || 1;
+      const prizes = calculatePrizeSplit(totalAmount, winnerCount);
+
+      if (token !== ETH_ADDRESS) {
+        // ERC-20: check allowance and approve if needed
+        const contractAddress = CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quinty as `0x${string}`;
+        const allowance = await readContract(wagmiConfig, {
+          address: token as `0x${string}`,
+          abi: ERC20_ABI,
+          functionName: "allowance",
+          args: [address, contractAddress],
+        }) as bigint;
+
+        if (allowance < totalAmount) {
+          // Need approval first
+          const { writeContractAsync } = await import("wagmi/actions").then(m => ({ writeContractAsync: m.writeContract }));
+          const approveHash = await writeContractAsync(wagmiConfig, {
+            address: token as `0x${string}`,
+            abi: ERC20_ABI,
+            functionName: "approve",
+            args: [contractAddress, totalAmount],
+          });
+          // Wait for approval
+          const { waitForTransactionReceipt } = await import("wagmi/actions");
+          await waitForTransactionReceipt(wagmiConfig, { hash: approveHash });
+        }
+
+        // Create bounty without value
+        writeContract({
+          address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quinty as `0x${string}`,
+          abi: QUINTY_ABI,
+          functionName: "createBounty",
+          args: [
+            formData.title,
+            `${formData.description}\n\nMetadata: ipfs://${metadataCid}`,
+            BigInt(openDeadlineTs),
+            BigInt(judgingDeadlineTs),
+            BigInt(formData.slashPercent),
+            prizes,
+            token as `0x${string}`,
+          ],
+        });
+      } else {
+        // ETH bounty
+        writeContract({
+          address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quinty as `0x${string}`,
+          abi: QUINTY_ABI,
+          functionName: "createBounty",
+          args: [
+            formData.title,
+            `${formData.description}\n\nMetadata: ipfs://${metadataCid}`,
+            BigInt(openDeadlineTs),
+            BigInt(judgingDeadlineTs),
+            BigInt(formData.slashPercent),
+            prizes,
+            ETH_ADDRESS as `0x${string}`,
+          ],
+          value: totalAmount,
+        });
+      }
     } catch (e: any) {
       console.error("Error creating bounty:", e);
       alert(`Error creating bounty: ${e.message || e}`);
@@ -104,9 +145,9 @@ export default function BountyManager() {
   };
 
   // Action handlers
-  const submitToBounty = async (bountyId: number, ipfsCid: string, socialHandle: string) => {
+  const submitToBounty = async (bountyId: number, ipfsCid: string) => {
     try {
-      // Get required deposit amount (1% of bounty)
+      const bounty = bounties.find(b => b.id === bountyId);
       const depositAmount = await readContract(wagmiConfig, {
         address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quinty as `0x${string}`,
         abi: QUINTY_ABI,
@@ -114,27 +155,56 @@ export default function BountyManager() {
         args: [BigInt(bountyId)],
       }) as bigint;
 
-      console.log("Submitting with deposit:", depositAmount.toString());
+      if (bounty && bounty.token !== ETH_ADDRESS) {
+        // ERC-20 deposit: approve then submit
+        const contractAddress = CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quinty as `0x${string}`;
+        const allowance = await readContract(wagmiConfig, {
+          address: bounty.token as `0x${string}`,
+          abi: ERC20_ABI,
+          functionName: "allowance",
+          args: [address!, contractAddress],
+        }) as bigint;
 
-      writeContract({
-        address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quinty as `0x${string}`,
-        abi: QUINTY_ABI,
-        functionName: "submitToBounty",
-        args: [BigInt(bountyId), ipfsCid, socialHandle],
-        value: depositAmount,
-      });
+        if (allowance < depositAmount) {
+          const { writeContract: writeContractAction } = await import("wagmi/actions");
+          const approveHash = await writeContractAction(wagmiConfig, {
+            address: bounty.token as `0x${string}`,
+            abi: ERC20_ABI,
+            functionName: "approve",
+            args: [contractAddress, depositAmount],
+          });
+          const { waitForTransactionReceipt } = await import("wagmi/actions");
+          await waitForTransactionReceipt(wagmiConfig, { hash: approveHash });
+        }
+
+        writeContract({
+          address: contractAddress,
+          abi: QUINTY_ABI,
+          functionName: "submitToBounty",
+          args: [BigInt(bountyId), ipfsCid],
+        });
+      } else {
+        // ETH deposit
+        writeContract({
+          address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quinty as `0x${string}`,
+          abi: QUINTY_ABI,
+          functionName: "submitToBounty",
+          args: [BigInt(bountyId), ipfsCid],
+          value: depositAmount,
+        });
+      }
     } catch (e: any) {
       console.error("Error submitting to bounty:", e);
       alert(`Error: ${e.message || e}`);
     }
   };
 
-  const selectWinner = async (bountyId: number, submissionId: number) => {
+  const selectWinners = async (bountyId: number, submissionIds: number[]) => {
     writeContract({
       address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quinty as `0x${string}`,
       abi: QUINTY_ABI,
-      functionName: "selectWinner",
-      args: [BigInt(bountyId), BigInt(submissionId)],
+      functionName: "selectWinners",
+      args: [BigInt(bountyId), submissionIds.map(id => BigInt(id))],
     });
   };
 
@@ -156,10 +226,8 @@ export default function BountyManager() {
     });
   };
 
-  // Handle transaction confirmation
   useEffect(() => {
     if (isConfirmed) {
-      console.log("Transaction confirmed!");
       refetch();
       if (activeTab === "create") {
         setActiveTab("browse");
@@ -169,7 +237,6 @@ export default function BountyManager() {
 
   return (
     <div className="space-y-10">
-      {/* Unified Header Section */}
       <div className="mb-10 text-center">
         <h1 className="text-3xl font-black text-slate-900 text-balance">Bounties</h1>
         <p className="text-slate-500 mt-1 text-sm font-medium text-pretty">
@@ -201,7 +268,6 @@ export default function BountyManager() {
         </div>
       </div>
 
-      {/* Content Area */}
       <div className="min-h-[400px]">
         <AnimatePresence mode="wait">
           {activeTab === "create" ? (
@@ -236,8 +302,6 @@ export default function BountyManager() {
                   ? filteredBounties
                   : bounties.filter(b => b.creator.toLowerCase() === address?.toLowerCase());
 
-                console.log(`${activeTab} tab - Showing ${displayBounties.length} bounties`, { address, totalBounties: bounties.length });
-
                 if (displayBounties.length === 0) {
                   return (
                     <div className="text-center py-16">
@@ -269,7 +333,7 @@ export default function BountyManager() {
                         key={b.id}
                         bounty={b}
                         onSubmitToBounty={submitToBounty}
-                        onSelectWinner={selectWinner}
+                        onSelectWinner={(bountyId, subId) => selectWinners(bountyId, [subId])}
                         onTriggerSlash={triggerSlash}
                         onRefundNoSubmissions={refundNoSubmissions}
                       />
@@ -287,7 +351,7 @@ export default function BountyManager() {
                         key={b.id}
                         bounty={b}
                         onSubmitToBounty={submitToBounty}
-                        onSelectWinner={selectWinner}
+                        onSelectWinner={(bountyId, subId) => selectWinners(bountyId, [subId])}
                         onTriggerSlash={triggerSlash}
                         onRefundNoSubmissions={refundNoSubmissions}
                       />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,7 +8,9 @@ import { cn } from "@/lib/utils";
 import { AnimatePresence, motion } from "framer-motion";
 import { Menu, X } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
+import { useAccount } from "wagmi";
 import LoginButton from "./auth/LoginButton";
+import { WithdrawalBanner } from "./WithdrawalBanner";
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
 import { getInitials } from "@/utils/format";
 import UserMenu from "./auth/UserMenu";
@@ -17,6 +19,7 @@ export default function Header() {
   const router = useRouter();
   const pathname = usePathname();
   const { profile, loading } = useAuth();
+  const { isConnected } = useAccount();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isMounted, setIsMounted] = useState(false);
   const [scrolled, setScrolled] = useState(false);
@@ -106,6 +109,9 @@ export default function Header() {
           </div>
         </div>
       </header>
+
+      {/* Withdrawal Banner */}
+      {isMounted && isConnected && <WithdrawalBanner />}
 
       {/* Mobile menu */}
       <AnimatePresence>

--- a/src/components/QuestCard.tsx
+++ b/src/components/QuestCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useRouter } from "next/navigation";
 import { formatETH, formatTimeLeft, formatAddress } from "../utils/web3";
+import { getTokenInfo, formatTokenAmount } from "../utils/contracts";
 import { Users, Clock, ArrowUpRight } from "lucide-react";
 import { useWalletName } from "@/hooks/useWalletName";
 import { QuestQuickView } from "./quests/QuestQuickView";
@@ -10,6 +11,7 @@ interface Quest {
   creator: string;
   title: string;
   description: string;
+  token: string;
   totalAmount: bigint;
   perQualifier: bigint;
   maxQualifiers: number;
@@ -40,6 +42,7 @@ export default function QuestCard({ quest, entryCount = 0 }: QuestCardProps) {
   const router = useRouter();
   const [quickView, setQuickView] = useState(false);
   const creatorName = useWalletName(quest.creator);
+  const tokenInfo = getTokenInfo(quest.token);
   const progress = Math.min((quest.qualifiersCount / quest.maxQualifiers) * 100, 100);
   const isExpired = Date.now() / 1000 > quest.deadline;
   const config = statusConfig(quest, isExpired);
@@ -116,8 +119,8 @@ export default function QuestCard({ quest, entryCount = 0 }: QuestCardProps) {
             {/* Reward */}
             <div>
               <div className="flex items-baseline gap-1">
-                <span className="text-lg font-bold text-zinc-900 tabular-nums tracking-tight">{formatETH(quest.perQualifier)}</span>
-                <span className="text-[10px] font-mono font-semibold text-zinc-400">ETH</span>
+                <span className="text-lg font-bold text-zinc-900 tabular-nums tracking-tight">{formatTokenAmount(quest.perQualifier, quest.token)}</span>
+                <span className="text-[10px] font-mono font-semibold text-zinc-400">{tokenInfo.symbol}</span>
               </div>
               <span className="text-[10px] font-mono text-zinc-300">per qualifier</span>
             </div>

--- a/src/components/WithdrawalBanner.tsx
+++ b/src/components/WithdrawalBanner.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import React from "react";
+import { useWithdrawals } from "../hooks/useWithdrawals";
+import { formatTokenAmount } from "../utils/contracts";
+import { Button } from "./ui/button";
+import { Loader2 } from "lucide-react";
+
+export function WithdrawalBanner() {
+    const { pendingBalances, hasPendingBalance, isWithdrawing, isConfirming, withdrawAll } = useWithdrawals();
+
+    if (!hasPendingBalance) return null;
+
+    return (
+        <div className="bg-emerald-50 border-b border-emerald-200">
+            <div className="max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8 py-2 flex items-center justify-between">
+                <div className="flex items-center gap-2 text-sm">
+                    <span className="text-emerald-600 font-medium">Pending withdrawals:</span>
+                    <div className="flex items-center gap-3">
+                        {pendingBalances.map((bal) => (
+                            <span key={bal.token} className="font-semibold text-emerald-800">
+                                {formatTokenAmount(bal.amount, bal.token)} {bal.symbol}
+                            </span>
+                        ))}
+                    </div>
+                </div>
+                <div className="flex items-center gap-2">
+                    {pendingBalances.map((bal) => (
+                        <Button
+                            key={bal.token}
+                            size="sm"
+                            onClick={() => withdrawAll(bal.token)}
+                            disabled={isWithdrawing || isConfirming}
+                            className="h-7 px-3 text-xs bg-emerald-600 hover:bg-emerald-700 text-white"
+                        >
+                            {isWithdrawing || isConfirming ? (
+                                <Loader2 className="size-3 animate-spin mr-1" />
+                            ) : null}
+                            Withdraw {bal.symbol}
+                        </Button>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/bounties/BountyQuickView.tsx
+++ b/src/components/bounties/BountyQuickView.tsx
@@ -38,7 +38,7 @@ export function BountyQuickView({ isOpen, onOpenChange, bounty, metadata, onView
           <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
           <div className="absolute bottom-6 left-8 right-8">
             <h2 className="text-2xl font-bold text-white mb-1">{metadata?.title || bounty.title || "Bounty Details"}</h2>
-            <p className="text-white/80 text-sm">Bounty #{bounty.id} • {formatETH(bounty.amount)} ETH</p>
+            <p className="text-white/80 text-sm">Bounty #{bounty.id} • {formatETH(bounty.totalAmount)} ETH</p>
           </div>
         </div>
 
@@ -46,7 +46,7 @@ export function BountyQuickView({ isOpen, onOpenChange, bounty, metadata, onView
           <div className="grid grid-cols-4 gap-4">
             <div className="p-4 bg-slate-50 border border-slate-100">
               <p className="text-[10px] uppercase tracking-wider font-bold text-slate-400 mb-1">Reward</p>
-              <p className="text-lg font-black text-[#0EA885]">{formatETH(bounty.amount)} ETH</p>
+              <p className="text-lg font-black text-[#0EA885]">{formatETH(bounty.totalAmount)} ETH</p>
             </div>
             <div className="p-4 bg-slate-50 border border-slate-100">
               <p className="text-[10px] uppercase tracking-wider font-bold text-slate-400 mb-1">Submissions</p>

--- a/src/components/bounties/DragToRank.tsx
+++ b/src/components/bounties/DragToRank.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import React, { useState } from "react";
+import { formatTokenAmount } from "../../utils/contracts";
+import { WalletName } from "../WalletName";
+import { Button } from "../ui/button";
+import { Trophy, X, GripVertical } from "lucide-react";
+
+interface Submission {
+    submitter: string;
+    ipfsCid: string;
+    deposit: bigint;
+    timestamp: bigint;
+}
+
+interface DragToRankProps {
+    submissions: Submission[];
+    prizes: bigint[];
+    token: string;
+    onSelectWinners: (submissionIds: number[]) => void;
+    disabled?: boolean;
+}
+
+const RANK_LABELS = ["1st", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th", "9th", "10th"];
+const RANK_COLORS = [
+    "border-amber-300 bg-amber-50",
+    "border-slate-300 bg-slate-50",
+    "border-orange-300 bg-orange-50",
+    "border-stone-200 bg-stone-50",
+    "border-stone-200 bg-stone-50",
+    "border-stone-200 bg-stone-50",
+    "border-stone-200 bg-stone-50",
+    "border-stone-200 bg-stone-50",
+    "border-stone-200 bg-stone-50",
+    "border-stone-200 bg-stone-50",
+];
+
+export function DragToRank({ submissions, prizes, token, onSelectWinners, disabled }: DragToRankProps) {
+    // ranked[slotIndex] = submissionIndex or null
+    const [ranked, setRanked] = useState<(number | null)[]>(
+        Array(prizes.length).fill(null)
+    );
+    const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+
+    const assignedIndices = new Set(ranked.filter((r): r is number => r !== null));
+    const unrankedSubmissions = submissions
+        .map((_, idx) => idx)
+        .filter((idx) => !assignedIndices.has(idx));
+
+    const handleDragStart = (submissionIndex: number) => {
+        setDraggedIndex(submissionIndex);
+    };
+
+    const handleDrop = (slotIndex: number) => {
+        if (draggedIndex === null) return;
+        const newRanked = [...ranked];
+        // Remove from current slot if already ranked
+        const existingSlot = newRanked.indexOf(draggedIndex);
+        if (existingSlot !== -1) {
+            newRanked[existingSlot] = null;
+        }
+        // If slot already has someone, swap them
+        if (newRanked[slotIndex] !== null) {
+            if (existingSlot !== -1) {
+                newRanked[existingSlot] = newRanked[slotIndex];
+            }
+        }
+        newRanked[slotIndex] = draggedIndex;
+        setRanked(newRanked);
+        setDraggedIndex(null);
+    };
+
+    const handleClickAssign = (submissionIndex: number) => {
+        const firstEmpty = ranked.indexOf(null);
+        if (firstEmpty === -1) return;
+        const newRanked = [...ranked];
+        newRanked[firstEmpty] = submissionIndex;
+        setRanked(newRanked);
+    };
+
+    const handleRemoveFromSlot = (slotIndex: number) => {
+        const newRanked = [...ranked];
+        newRanked[slotIndex] = null;
+        setRanked(newRanked);
+    };
+
+    const filledSlots = ranked.filter((r) => r !== null).length;
+    const canSubmit = filledSlots > 0;
+
+    const handleSubmit = () => {
+        const winnerIds = ranked.filter((r): r is number => r !== null);
+        onSelectWinners(winnerIds);
+    };
+
+    return (
+        <div className="space-y-4">
+            <h3 className="text-sm font-bold text-stone-700 flex items-center gap-2">
+                <Trophy className="size-4 text-amber-500" />
+                Select Winners ({filledSlots}/{prizes.length})
+            </h3>
+
+            {/* Prize Slots */}
+            <div className="space-y-2">
+                {prizes.map((prize, slotIndex) => (
+                    <div
+                        key={slotIndex}
+                        onDragOver={(e) => e.preventDefault()}
+                        onDrop={() => handleDrop(slotIndex)}
+                        className={`flex items-center gap-3 p-3 border-2 rounded transition-all ${
+                            RANK_COLORS[slotIndex] || RANK_COLORS[3]
+                        } ${draggedIndex !== null ? "border-dashed" : ""}`}
+                    >
+                        <div className="flex-shrink-0 w-12 text-center">
+                            <span className="text-xs font-bold text-stone-500">{RANK_LABELS[slotIndex]}</span>
+                            <p className="text-[10px] text-stone-400">{formatTokenAmount(prize, token)}</p>
+                        </div>
+
+                        {ranked[slotIndex] !== null ? (
+                            <div className="flex-1 flex items-center justify-between">
+                                <div className="flex items-center gap-2">
+                                    <GripVertical className="size-4 text-stone-300" />
+                                    <span className="text-sm font-medium text-stone-700">
+                                        <WalletName address={submissions[ranked[slotIndex]!].submitter} />
+                                    </span>
+                                </div>
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    onClick={() => handleRemoveFromSlot(slotIndex)}
+                                    className="size-6 text-stone-400 hover:text-red-500"
+                                >
+                                    <X className="size-3" />
+                                </Button>
+                            </div>
+                        ) : (
+                            <div className="flex-1 text-center">
+                                <p className="text-xs text-stone-400">
+                                    {draggedIndex !== null ? "Drop here" : "Click a submission to assign"}
+                                </p>
+                            </div>
+                        )}
+                    </div>
+                ))}
+            </div>
+
+            {/* Unranked Submissions */}
+            {unrankedSubmissions.length > 0 && (
+                <div className="space-y-1">
+                    <p className="text-xs text-stone-400 font-medium uppercase tracking-wider">Available Submissions</p>
+                    {unrankedSubmissions.map((idx) => (
+                        <div
+                            key={idx}
+                            draggable
+                            onDragStart={() => handleDragStart(idx)}
+                            onClick={() => handleClickAssign(idx)}
+                            className="flex items-center gap-2 p-2 border border-stone-200 bg-white cursor-pointer hover:border-[#0EA885] hover:bg-emerald-50/50 transition-all"
+                        >
+                            <GripVertical className="size-4 text-stone-300 flex-shrink-0" />
+                            <span className="text-sm text-stone-700">
+                                <WalletName address={submissions[idx].submitter} />
+                            </span>
+                            <span className="text-xs text-stone-400 ml-auto">#{idx}</span>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {/* Submit Button */}
+            <Button
+                onClick={handleSubmit}
+                disabled={!canSubmit || disabled}
+                className="w-full bg-[#0EA885] hover:bg-[#0c8a6f] text-white font-semibold h-11"
+            >
+                <Trophy className="size-4 mr-2" />
+                {filledSlots === 1 ? "Select Winner" : `Select ${filledSlots} Winners`}
+            </Button>
+
+            {filledSlots < prizes.length && filledSlots > 0 && (
+                <p className="text-xs text-stone-400 text-center">
+                    {prizes.length - filledSlots} unused prize slot(s) will be refunded to creator
+                </p>
+            )}
+        </div>
+    );
+}

--- a/src/components/quests/QuestForm.tsx
+++ b/src/components/quests/QuestForm.tsx
@@ -8,6 +8,8 @@ import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { Calendar } from "../ui/calendar";
 import { format, startOfDay } from "date-fns";
 import { ImageUpload } from "../ui/image-upload";
+import { TokenSelector } from "../ui/TokenSelector";
+import { ETH_ADDRESS, getTokenInfo } from "../../utils/contracts";
 
 type QuestType = "development" | "design" | "marketing" | "research" | "other";
 
@@ -34,6 +36,7 @@ export function QuestForm({ onSubmit, isPending }: QuestFormProps) {
         requirements: "",
         imageUrl: "",
         questType: "other" as QuestType,
+        token: ETH_ADDRESS,
     });
 
     const [deadlineDate, setDeadlineDate] = useState<Date>();
@@ -50,6 +53,7 @@ export function QuestForm({ onSubmit, isPending }: QuestFormProps) {
         onSubmit({
             ...formData,
             deadline: deadlineDateTime.toISOString(),
+            token: formData.token,
         });
     };
 
@@ -136,9 +140,19 @@ export function QuestForm({ onSubmit, isPending }: QuestFormProps) {
                         </div>
 
                         <div className="space-y-4">
+                            <div className="space-y-1.5">
+                                <label className="text-xs font-bold text-slate-400 uppercase tracking-wider">Payment Token</label>
+                                <TokenSelector
+                                    value={formData.token}
+                                    onChange={(v) => setFormData({ ...formData, token: v })}
+                                />
+                            </div>
+
                             <div className="grid grid-cols-2 gap-4">
                                 <div className="space-y-1.5">
-                                    <label className="text-xs font-bold text-slate-400 uppercase tracking-wider">Reward / User</label>
+                                    <label className="text-xs font-bold text-slate-400 uppercase tracking-wider">
+                                        Reward / User ({getTokenInfo(formData.token).symbol})
+                                    </label>
                                     <div className="relative">
                                         <Coins className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-300" />
                                         <Input
@@ -199,7 +213,7 @@ export function QuestForm({ onSubmit, isPending }: QuestFormProps) {
                                 <div className="flex items-center justify-between mb-1">
                                     <span className="text-xs font-bold text-slate-700">Total Escrow</span>
                                     <span className="text-base font-black text-[#0EA885]">
-                                        {(parseFloat(formData.perQualifier) || 0) * (formData.maxQualifiers || 0)} ETH
+                                        {(parseFloat(formData.perQualifier) || 0) * (formData.maxQualifiers || 0)} {getTokenInfo(formData.token).symbol}
                                     </span>
                                 </div>
                                 <p className="text-[10px] text-slate-400 leading-relaxed">This amount will be locked in the contract until distribution.</p>

--- a/src/components/quests/VerifierManagement.tsx
+++ b/src/components/quests/VerifierManagement.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import React, { useState } from "react";
+import { useWriteContract, useWaitForTransactionReceipt } from "wagmi";
+import { CONTRACT_ADDRESSES, QUEST_ABI, BASE_SEPOLIA_CHAIN_ID } from "../../utils/contracts";
+import { WalletName } from "../WalletName";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Shield, Plus, Trash2, Loader2 } from "lucide-react";
+
+interface VerifierManagementProps {
+    questId: number;
+    verifiers: string[];
+    onUpdate: () => void;
+}
+
+function isValidAddress(addr: string): boolean {
+    return /^0x[0-9a-fA-F]{40}$/.test(addr);
+}
+
+export function VerifierManagement({ questId, verifiers, onUpdate }: VerifierManagementProps) {
+    const [newVerifier, setNewVerifier] = useState("");
+    const { writeContract, data: hash, isPending } = useWriteContract();
+    const { isLoading: isConfirming, isSuccess: isConfirmed } = useWaitForTransactionReceipt({ hash });
+
+    React.useEffect(() => {
+        if (isConfirmed) {
+            setNewVerifier("");
+            onUpdate();
+        }
+    }, [isConfirmed, onUpdate]);
+
+    const handleAdd = () => {
+        if (!isValidAddress(newVerifier)) return;
+        writeContract({
+            address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quest as `0x${string}`,
+            abi: QUEST_ABI,
+            functionName: "addVerifier",
+            args: [BigInt(questId), newVerifier as `0x${string}`],
+        });
+    };
+
+    const handleRemove = (verifier: string) => {
+        writeContract({
+            address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quest as `0x${string}`,
+            abi: QUEST_ABI,
+            functionName: "removeVerifier",
+            args: [BigInt(questId), verifier as `0x${string}`],
+        });
+    };
+
+    return (
+        <div className="bg-white border border-stone-200 p-4">
+            <h3 className="text-sm font-bold text-stone-700 flex items-center gap-2 mb-3">
+                <Shield className="size-4 text-violet-500" />
+                Delegated Verifiers
+            </h3>
+
+            {/* Verifier List */}
+            {verifiers.length > 0 ? (
+                <div className="space-y-2 mb-3">
+                    {verifiers.map((v) => (
+                        <div key={v} className="flex items-center justify-between p-2 bg-stone-50 border border-stone-100">
+                            <span className="text-sm text-stone-700">
+                                <WalletName address={v} />
+                            </span>
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => handleRemove(v)}
+                                disabled={isPending || isConfirming}
+                                className="size-7 text-stone-400 hover:text-red-500"
+                            >
+                                <Trash2 className="size-3" />
+                            </Button>
+                        </div>
+                    ))}
+                </div>
+            ) : (
+                <p className="text-xs text-stone-400 mb-3">No delegated verifiers. Only you can verify entries.</p>
+            )}
+
+            {/* Add Verifier */}
+            <div className="flex gap-2">
+                <Input
+                    placeholder="0x..."
+                    value={newVerifier}
+                    onChange={(e) => setNewVerifier(e.target.value)}
+                    className="flex-1 h-9 text-sm border-stone-200"
+                />
+                <Button
+                    onClick={handleAdd}
+                    disabled={!isValidAddress(newVerifier) || isPending || isConfirming}
+                    size="sm"
+                    className="h-9 bg-violet-600 hover:bg-violet-700 text-white"
+                >
+                    {isPending || isConfirming ? (
+                        <Loader2 className="size-3 animate-spin" />
+                    ) : (
+                        <Plus className="size-3" />
+                    )}
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/ui/TokenSelector.tsx
+++ b/src/components/ui/TokenSelector.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import React from "react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./select";
+import { SUPPORTED_TOKENS, ETH_ADDRESS } from "../../utils/contracts";
+
+interface TokenSelectorProps {
+    value: string;
+    onChange: (tokenAddress: string) => void;
+    disabled?: boolean;
+}
+
+export function TokenSelector({ value, onChange, disabled }: TokenSelectorProps) {
+    return (
+        <Select value={value} onValueChange={onChange} disabled={disabled}>
+            <SelectTrigger className="border-slate-200 bg-white">
+                <SelectValue placeholder="Select token" />
+            </SelectTrigger>
+            <SelectContent>
+                {SUPPORTED_TOKENS.map((token) => (
+                    <SelectItem key={token.address} value={token.address}>
+                        <span className="flex items-center gap-2">
+                            <span className="text-xs font-mono">
+                                {token.symbol === "ETH" ? "⟠" : "🪙"}
+                            </span>
+                            {token.symbol}
+                        </span>
+                    </SelectItem>
+                ))}
+            </SelectContent>
+        </Select>
+    );
+}

--- a/src/hooks/useBounties.ts
+++ b/src/hooks/useBounties.ts
@@ -1,14 +1,13 @@
 import { useState, useEffect, useCallback } from "react";
 import { useReadContract, useWatchContractEvent } from "wagmi";
 import { readContract } from "@wagmi/core";
-import { CONTRACT_ADDRESSES, QUINTY_ABI, BASE_SEPOLIA_CHAIN_ID } from "../utils/contracts";
+import { CONTRACT_ADDRESSES, QUINTY_ABI, BASE_SEPOLIA_CHAIN_ID, ETH_ADDRESS } from "../utils/contracts";
 import { wagmiConfig } from "../utils/web3";
 
 export interface Submission {
     submitter: string;
     ipfsCid: string;
-    socialHandle: string;
-    deposit: bigint;      // 1% deposit amount
+    deposit: bigint;
     timestamp: bigint;
 }
 
@@ -17,13 +16,13 @@ export interface Bounty {
     creator: string;
     title: string;
     description: string;
-    amount: bigint;
-    openDeadline: bigint;     // When submissions close
-    judgingDeadline: bigint;  // When must select winner (or get slashed)
-    slashPercent: bigint;     // 2500-5000 (25%-50% in basis points)
-    status: number; // 0: OPEN, 1: JUDGING, 2: RESOLVED, 3: SLASHED
-    selectedWinner: string;
-    selectedSubmissionId: bigint;
+    token: string;           // address(0) for ETH, token address for ERC-20
+    totalAmount: bigint;     // total prize pool
+    prizes: bigint[];        // ranked prize tiers
+    openDeadline: bigint;
+    judgingDeadline: bigint;
+    slashPercent: bigint;    // 2500-5000 (25%-50% in basis points)
+    status: number;          // 0: OPEN, 1: JUDGING, 2: RESOLVED, 3: SLASHED
     submissionCount: number;
     totalDeposits: bigint;
     submissions: Submission[];
@@ -51,12 +50,10 @@ export function useBounties() {
             const loadedBounties: Bounty[] = [];
             const counter = Number(bountyCounter);
 
-            // Fetch bounties in parallel
             const bountyPromises = Array.from({ length: counter }, (_, i) => {
                 const id = i + 1;
                 return (async () => {
                     try {
-                        // Get bounty data
                         const bountyData = (await readContract(wagmiConfig, {
                             address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quinty as `0x${string}`,
                             abi: QUINTY_ABI,
@@ -64,7 +61,6 @@ export function useBounties() {
                             args: [BigInt(id)],
                         })) as any[];
 
-                        // Get all submissions
                         const submissions = (await readContract(wagmiConfig, {
                             address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quinty as `0x${string}`,
                             abi: QUINTY_ABI,
@@ -75,18 +71,19 @@ export function useBounties() {
                         const description = bountyData[2];
                         const metadataMatch = description.match(/Metadata: ipfs:\/\/([a-zA-Z0-9]+)/);
 
+                        // V3 getBounty returns: creator, title, description, token, totalAmount, prizes[], openDeadline, judgingDeadline, slashPercent, status, submissionCount, totalDeposits
                         return {
                             id,
                             creator: bountyData[0],
                             title: bountyData[1],
                             description: description,
-                            amount: bountyData[3],
-                            openDeadline: bountyData[4],
-                            judgingDeadline: bountyData[5],
-                            slashPercent: bountyData[6],
-                            status: Number(bountyData[7]),
-                            selectedWinner: bountyData[8],
-                            selectedSubmissionId: bountyData[9],
+                            token: bountyData[3],
+                            totalAmount: bountyData[4],
+                            prizes: bountyData[5] as bigint[],
+                            openDeadline: bountyData[6],
+                            judgingDeadline: bountyData[7],
+                            slashPercent: bountyData[8],
+                            status: Number(bountyData[9]),
                             submissionCount: Number(bountyData[10]),
                             totalDeposits: bountyData[11],
                             submissions: submissions as Submission[],
@@ -134,7 +131,7 @@ export function useBounties() {
     useWatchContractEvent({
         address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quinty as `0x${string}`,
         abi: QUINTY_ABI,
-        eventName: "WinnerSelected",
+        eventName: "WinnersSelected",
         onLogs() {
             loadBounties();
         },

--- a/src/hooks/useWithdrawals.ts
+++ b/src/hooks/useWithdrawals.ts
@@ -1,0 +1,167 @@
+import { useCallback, useEffect, useState } from "react";
+import { useAccount, useWriteContract, useWaitForTransactionReceipt } from "wagmi";
+import { readContract } from "@wagmi/core";
+import {
+    CONTRACT_ADDRESSES,
+    QUINTY_ABI,
+    QUEST_ABI,
+    BASE_SEPOLIA_CHAIN_ID,
+    ETH_ADDRESS,
+    USDC_BASE_SEPOLIA,
+} from "../utils/contracts";
+import { wagmiConfig } from "../utils/web3";
+
+export interface PendingBalance {
+    token: string;
+    symbol: string;
+    decimals: number;
+    amount: bigint;
+}
+
+export function useWithdrawals() {
+    const { address } = useAccount();
+    const [pendingBalances, setPendingBalances] = useState<PendingBalance[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+    const { writeContract, data: hash, isPending: isWithdrawing } = useWriteContract();
+    const { isLoading: isConfirming, isSuccess: isConfirmed } = useWaitForTransactionReceipt({ hash });
+
+    const loadBalances = useCallback(async () => {
+        if (!address) {
+            setPendingBalances([]);
+            return;
+        }
+
+        setIsLoading(true);
+        try {
+            const tokens = [
+                { address: ETH_ADDRESS, symbol: "ETH", decimals: 18 },
+                { address: USDC_BASE_SEPOLIA, symbol: "USDC", decimals: 6 },
+            ];
+
+            const balances: PendingBalance[] = [];
+
+            for (const token of tokens) {
+                let total = 0n;
+
+                // Check Quinty contract
+                try {
+                    const quintyBalance = await readContract(wagmiConfig, {
+                        address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quinty as `0x${string}`,
+                        abi: QUINTY_ABI,
+                        functionName: "pendingBalance",
+                        args: [token.address as `0x${string}`, address],
+                    }) as bigint;
+                    total += quintyBalance;
+                } catch {}
+
+                // Check Quest contract
+                try {
+                    const questBalance = await readContract(wagmiConfig, {
+                        address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quest as `0x${string}`,
+                        abi: QUEST_ABI,
+                        functionName: "pendingBalance",
+                        args: [token.address as `0x${string}`, address],
+                    }) as bigint;
+                    total += questBalance;
+                } catch {}
+
+                if (total > 0n) {
+                    balances.push({
+                        token: token.address,
+                        symbol: token.symbol,
+                        decimals: token.decimals,
+                        amount: total,
+                    });
+                }
+            }
+
+            setPendingBalances(balances);
+        } catch (error) {
+            console.error("Error loading withdrawal balances:", error);
+        } finally {
+            setIsLoading(false);
+        }
+    }, [address]);
+
+    useEffect(() => {
+        loadBalances();
+        const interval = setInterval(loadBalances, 15000);
+        return () => clearInterval(interval);
+    }, [loadBalances]);
+
+    // Refresh after successful withdrawal
+    useEffect(() => {
+        if (isConfirmed) {
+            loadBalances();
+        }
+    }, [isConfirmed, loadBalances]);
+
+    const withdrawETH = useCallback(async (contract: "Quinty" | "Quest") => {
+        const abi = contract === "Quinty" ? QUINTY_ABI : QUEST_ABI;
+        writeContract({
+            address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID][contract] as `0x${string}`,
+            abi,
+            functionName: "withdrawETH",
+        });
+    }, [writeContract]);
+
+    const withdrawToken = useCallback(async (contract: "Quinty" | "Quest", tokenAddress: string) => {
+        const abi = contract === "Quinty" ? QUINTY_ABI : QUEST_ABI;
+        writeContract({
+            address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID][contract] as `0x${string}`,
+            abi,
+            functionName: "withdrawToken",
+            args: [tokenAddress as `0x${string}`],
+        });
+    }, [writeContract]);
+
+    // Convenience: withdraw all of a given token from both contracts
+    const withdrawAll = useCallback(async (tokenAddress: string) => {
+        if (tokenAddress === ETH_ADDRESS) {
+            // Try Quinty first
+            try {
+                const quintyBal = await readContract(wagmiConfig, {
+                    address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quinty as `0x${string}`,
+                    abi: QUINTY_ABI,
+                    functionName: "pendingBalance",
+                    args: [ETH_ADDRESS as `0x${string}`, address!],
+                }) as bigint;
+                if (quintyBal > 0n) {
+                    withdrawETH("Quinty");
+                    return;
+                }
+            } catch {}
+            // Then Quest
+            withdrawETH("Quest");
+        } else {
+            try {
+                const quintyBal = await readContract(wagmiConfig, {
+                    address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quinty as `0x${string}`,
+                    abi: QUINTY_ABI,
+                    functionName: "pendingBalance",
+                    args: [tokenAddress as `0x${string}`, address!],
+                }) as bigint;
+                if (quintyBal > 0n) {
+                    withdrawToken("Quinty", tokenAddress);
+                    return;
+                }
+            } catch {}
+            withdrawToken("Quest", tokenAddress);
+        }
+    }, [address, withdrawETH, withdrawToken]);
+
+    const hasPendingBalance = pendingBalances.length > 0;
+
+    return {
+        pendingBalances,
+        hasPendingBalance,
+        isLoading,
+        isWithdrawing,
+        isConfirming,
+        isConfirmed,
+        withdrawAll,
+        withdrawETH,
+        withdrawToken,
+        refetch: loadBalances,
+    };
+}

--- a/src/utils/contracts.ts
+++ b/src/utils/contracts.ts
@@ -1,24 +1,58 @@
-// Contract addresses and ABIs for Quinty V2 on Base Sepolia
+// Contract addresses and ABIs for Quinty V3 on Base Sepolia
 import QuintyABI from "../../contracts/Quinty.json";
 import QuintyNFTABI from "../../contracts/QuintyNFT.json";
 import QuintyReputationABI from "../../contracts/QuintyReputation.json";
 import QuestABI from "../../contracts/Quest.json";
 import ZKVerificationABI from "../../contracts/ZKVerification.json";
 
-// Legacy import for backward compatibility
-import AirdropBountyABI from "../../contracts/AirdropBounty.json";
-
 export const BASE_SEPOLIA_CHAIN_ID = 84532;
 
+// USDC on Base Sepolia (6 decimals)
+export const USDC_BASE_SEPOLIA = "0x036CbD53842c5426634e7929541eC2318f3dCF7e";
+
+// address(0) sentinel for native ETH
+export const ETH_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+// Minimal ERC-20 ABI for approve/allowance
+export const ERC20_ABI = [
+  {
+    inputs: [{ name: "spender", type: "address" }, { name: "amount", type: "uint256" }],
+    name: "approve",
+    outputs: [{ name: "", type: "bool" }],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [{ name: "owner", type: "address" }, { name: "spender", type: "address" }],
+    name: "allowance",
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ name: "account", type: "address" }],
+    name: "balanceOf",
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "decimals",
+    outputs: [{ name: "", type: "uint8" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
 // Contract addresses on Base Sepolia
-// Updated: 2026-02-10 - Fresh deployment for incuBase milestone
+// Updated: 2026-02-25 - V3 deployment (multi-winner, ERC-20, pull withdrawals)
 export const CONTRACT_ADDRESSES = {
   [BASE_SEPOLIA_CHAIN_ID]: {
     Quinty: "0x034cf0b72BcB1b529a2B0458275E0307CD6b5459",
     QuintyNFT: "0x6fcd78D8BB923E20B3C657C65f64A20a4a6b9884",
     QuintyReputation: "0x3Fc6d21B3AC4E419a2bEe6BeB40E00FfF2bF1014",
     Quest: "0x86cc170e725784812A31F548c434e425bc0181B1",
-    AirdropBounty: "0x86cc170e725784812A31F548c434e425bc0181B1", // Legacy alias (points to Quest)
     ZKVerification: "0x045Fb080d926f049db7597c99B56aEccc8977F36",
   },
 };
@@ -28,14 +62,13 @@ export const QUINTY_ABI = QuintyABI;
 export const QUINTY_NFT_ABI = QuintyNFTABI;
 export const REPUTATION_ABI = QuintyReputationABI;
 export const QUEST_ABI = QuestABI;
-export const AIRDROP_ABI = AirdropBountyABI; // Legacy
 export const ZK_VERIFICATION_ABI = ZKVerificationABI;
 
-// Bounty Status Enum (incuBase milestone - phases)
+// Bounty Status Enum (V3 - phases)
 export enum BountyStatus {
   OPEN = 0,      // Accepting submissions (before openDeadline)
   JUDGING = 1,   // Creator judging submissions (before judgingDeadline)
-  RESOLVED = 2,  // Winner selected and paid
+  RESOLVED = 2,  // Winners selected and paid
   SLASHED = 3,   // Creator slashed for not selecting winner
 }
 
@@ -52,8 +85,13 @@ export enum BadgeType {
   TeamMember = 2,
 }
 
+// Token config for UI
+export const SUPPORTED_TOKENS = [
+  { address: ETH_ADDRESS, symbol: "ETH", decimals: 18, name: "Ethereum" },
+  { address: USDC_BASE_SEPOLIA, symbol: "USDC", decimals: 6, name: "USD Coin" },
+] as const;
+
 // Constants
-export const MIN_VOTING_STAKE = "0.0001";
 export const BASE_SEPOLIA_EXPLORER = "https://sepolia-explorer.base.org";
 
 // Helper function to get contract address
@@ -64,4 +102,71 @@ export function getContractAddress(contractName: keyof typeof CONTRACT_ADDRESSES
 // Helper to get explorer URL
 export function getExplorerUrl(addressOrTx: string, type: 'address' | 'tx' = 'address'): string {
   return `${BASE_SEPOLIA_EXPLORER}/${type}/${addressOrTx}`;
+}
+
+// Helper to get token info by address
+export function getTokenInfo(tokenAddress: string) {
+  return SUPPORTED_TOKENS.find(t => t.address.toLowerCase() === tokenAddress.toLowerCase()) || SUPPORTED_TOKENS[0];
+}
+
+// Helper to format token amount based on decimals
+export function formatTokenAmount(amount: bigint, tokenAddress: string): string {
+  const token = getTokenInfo(tokenAddress);
+  const divisor = BigInt(10 ** token.decimals);
+  const whole = amount / divisor;
+  const fraction = amount % divisor;
+  const fractionStr = fraction.toString().padStart(token.decimals, '0');
+  // Trim trailing zeros but keep at least 2 decimal places for USDC, 4 for ETH
+  const minDecimals = token.symbol === "USDC" ? 2 : 4;
+  const trimmed = fractionStr.slice(0, Math.max(minDecimals, fractionStr.search(/0*$/) || minDecimals));
+  return `${whole}.${trimmed}`;
+}
+
+// Helper to parse token amount string to bigint
+export function parseTokenAmount(amount: string, tokenAddress: string): bigint {
+  const token = getTokenInfo(tokenAddress);
+  const [whole, fraction = ""] = amount.split(".");
+  const paddedFraction = fraction.padEnd(token.decimals, "0").slice(0, token.decimals);
+  return BigInt(whole || "0") * BigInt(10 ** token.decimals) + BigInt(paddedFraction);
+}
+
+// Calculate prize split for multi-winner bounties
+export function calculatePrizeSplit(totalAmount: bigint, winnerCount: number): bigint[] {
+  if (winnerCount <= 0) return [];
+  if (winnerCount === 1) return [totalAmount];
+  if (winnerCount === 2) {
+    const first = totalAmount * 60n / 100n;
+    return [first, totalAmount - first];
+  }
+  if (winnerCount === 3) {
+    const first = totalAmount * 50n / 100n;
+    const second = totalAmount * 30n / 100n;
+    return [first, second, totalAmount - first - second];
+  }
+  // 4+ winners: proportional decrease, minimum 5% for last
+  const shares: number[] = [];
+  let remaining = 100;
+  for (let i = 0; i < winnerCount; i++) {
+    if (i === winnerCount - 1) {
+      shares.push(remaining);
+    } else {
+      const share = Math.max(Math.floor(remaining * 0.4), 5);
+      shares.push(share);
+      remaining -= share;
+    }
+  }
+  // Ensure minimum 5% for last
+  if (shares[shares.length - 1] < 5) {
+    const deficit = 5 - shares[shares.length - 1];
+    shares[0] -= deficit;
+    shares[shares.length - 1] = 5;
+  }
+  // Convert to bigint amounts
+  let allocated = 0n;
+  return shares.map((pct, i) => {
+    if (i === shares.length - 1) return totalAmount - allocated;
+    const amount = totalAmount * BigInt(pct) / 100n;
+    allocated += amount;
+    return amount;
+  });
 }


### PR DESCRIPTION
## Summary

Complete frontend update for Quinty V3 and Quest V2 smart contract changes:

- **Multi-winner bounties**: Drag-to-rank interface for selecting up to 10 winners with auto-calculated prize tiers
- **ERC-20 token support**: ETH + USDC dropdown with approval-then-create flow
- **Pull-based withdrawals**: Global banner in header showing pending balances with one-click withdraw
- **Delegated verifiers**: Quest creators can add/remove verifiers from quest detail page
- **Removed socialHandle**: All X account requirements removed from submissions and entries

### New Components
- `TokenSelector` — ETH/USDC dropdown for forms
- `WithdrawalBanner` — Global pending balance indicator + withdraw buttons
- `DragToRank` — Visual ranked slot interface for multi-winner selection
- `VerifierManagement` — Add/remove delegated verifiers for quest creators

### Updated Files (17 modified, 7 new)
- Contract ABIs (Quinty, Quest, QuintyReputation)
- Hooks (useBounties, useQuests, new useWithdrawals)
- Forms (BountyForm, QuestForm)
- Managers (BountyManager, QuestManager)
- Detail pages (bounties/[id], quests/[id])
- Cards (BountyCard, QuestCard)
- Header, contracts utility

## Test plan
- [ ] ETH bounty creation (single and multi-winner)
- [ ] USDC bounty creation with approval flow
- [ ] Bounty submission with deposit (ETH and USDC)
- [ ] Multi-winner selection via drag-to-rank
- [ ] ETH and USDC quest creation
- [ ] Quest entry submission (no X account required)
- [ ] Quest entry verification by creator
- [ ] Add/remove delegated verifier
- [ ] Withdrawal banner appears with pending balance
- [ ] Per-token withdraw functions

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: Frontend-only changes, no server-side impact. Contract interactions are user-initiated via wallet signing.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)