### PR TITLE
fix: profile card width, auth sync, and submit solution tx

### DIFF
--- a/src/app/bounties/[id]/page.tsx
+++ b/src/app/bounties/[id]/page.tsx
@@ -207,7 +207,14 @@ export default function BountyDetailPage() {
   };
 
   useEffect(() => { if (bountyId) loadBounty(); }, [bountyId, address]);
-  useEffect(() => { if (isConfirmed) loadBounty(); }, [isConfirmed]);
+  useEffect(() => {
+    if (isConfirmed) {
+      setUploadedSolutionImage(null);
+      setSubmissionText("");
+      setShowSubmitForm(false);
+      loadBounty();
+    }
+  }, [isConfirmed]);
 
   // Load viewing metadata
   useEffect(() => {
@@ -299,9 +306,6 @@ export default function BountyDetailPage() {
         });
       }
 
-      setUploadedSolutionImage(null);
-      setSubmissionText("");
-      setShowSubmitForm(false);
     } catch (error) {
       console.error("Error submitting solution:", error);
       showAlert({ title: "Submission Failed", description: "Failed to submit solution. Please try again." });

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -376,28 +376,28 @@ export default function ProfilePage() {
                         )}
                     </div>
 
-                    <div className="flex items-start justify-between gap-4">
-                        <div className="flex-1">
-                            <div className="flex items-center gap-2 mb-3">
-                                <Wallet className="w-4 h-4 text-[#0EA885]" />
-                                <span className="text-xs font-mono font-semibold uppercase tracking-wider text-zinc-500">Wallet Address</span>
-                            </div>
+                    <div>
+                        <div className="flex items-center gap-2 mb-3">
+                            <Wallet className="w-4 h-4 text-[#0EA885]" />
+                            <span className="text-xs font-mono font-semibold uppercase tracking-wider text-zinc-500">Wallet Address</span>
+                        </div>
+                        <div className="flex items-start justify-between gap-4">
                             <div className="flex items-center gap-2">
                                 <span className="font-mono text-sm font-semibold text-zinc-900">{formatAddress(address || "")}</span>
                                 <button onClick={copyAddress} className="p-1.5 hover:bg-[#0EA885]/5 transition-colors border border-zinc-200 hover:border-[#0EA885]/30" title="Copy address">
                                     {copiedAddress ? <Check className="w-3.5 h-3.5 text-[#0EA885]" /> : <Copy className="w-3.5 h-3.5 text-zinc-400" />}
                                 </button>
                             </div>
-                        </div>
-                        <div className="text-right">
-                            <div className="flex items-center justify-end gap-2 mb-3">
-                                <span className="text-xs font-mono font-semibold uppercase tracking-wider text-zinc-500">Balance</span>
+                            <div className="text-right">
+                                <div className="flex items-center justify-end gap-1 mb-1">
+                                    <span className="text-xs font-mono font-semibold uppercase tracking-wider text-zinc-500">Balance</span>
+                                </div>
+                                <div className="flex items-baseline gap-1 justify-end">
+                                    <span className="text-2xl font-semibold text-zinc-900 tabular-nums font-heading">{balanceData ? formatETH(balanceData.value) : "0.00"}</span>
+                                    <span className="text-xs font-mono font-semibold text-zinc-400">ETH</span>
+                                </div>
+                                <div className="text-xs font-mono text-zinc-400 mt-1">{balanceData?.symbol || "ETH"} · Base Sepolia</div>
                             </div>
-                            <div className="flex items-baseline gap-1 justify-end">
-                                <span className="text-2xl font-semibold text-zinc-900 tabular-nums font-heading">{balanceData ? formatETH(balanceData.value) : "0.00"}</span>
-                                <span className="text-xs font-mono font-semibold text-zinc-400">ETH</span>
-                            </div>
-                            <div className="text-xs font-mono text-zinc-400 mt-1">{balanceData?.symbol || "ETH"} · Base Sepolia</div>
                         </div>
                     </div>
                 </div>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -73,7 +73,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, [isConnected, authenticated]);
 
-  // Sync profile with backend when Privy user changes
+  // Sync profile with backend when Privy user or wallet address changes
   useEffect(() => {
     if (!ready) {
       setLoading(true);
@@ -82,11 +82,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     if (authenticated && privyUser) {
       syncProfile();
+    } else if (isConnected && address && !profile) {
+      // Wallet connected but Privy state hasn't propagated yet — retry sync shortly
+      const timer = setTimeout(() => {
+        if (authenticated && privyUser) {
+          syncProfile();
+        }
+      }, 500);
+      return () => clearTimeout(timer);
     } else {
       setProfile(null);
       setLoading(false);
     }
-  }, [ready, authenticated, privyUser]);
+  }, [ready, authenticated, privyUser, address]);
 
   const syncProfile = async () => {
     try {


### PR DESCRIPTION
## Summary
- **Profile card width**: Wallet Address label now spans full width like Display Name and X Account sections (was squeezed by flex two-column layout)
- **Auth state sync**: Profile page no longer shows "Please sign in" after connecting wallet on /dashboard — added `address` to useEffect deps with retry logic
- **Submit solution TX**: Wallet popup now actually appears — moved form cleanup to `isConfirmed` effect instead of running immediately after `writeContract()`

## Test plan
- [ ] Go to /profile — verify Display Name, X Account, Wallet Address sections are all same width
- [ ] Connect wallet on /dashboard, navigate to /profile — should show profile without refresh
- [ ] On bounty detail, submit solution — wallet should prompt for tx approval after IPFS upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)