### PR TITLE
feat: Admin Moderation Panel & Content Hiding

### DIFF
--- a/docs/brainstorms/2026-03-07-admin-moderation-brainstorm.md
+++ b/docs/brainstorms/2026-03-07-admin-moderation-brainstorm.md
@@ -1,0 +1,88 @@
+---
+title: "feat: Admin Moderation & Content Hiding"
+type: feat
+status: complete
+date: 2026-03-07
+---
+
+# Admin Moderation & Content Hiding
+
+## Problem
+
+Users can create duplicate or spam bounties/quests. There's no way for an admin to remove or hide them. Currently:
+- All bounties/quests are read directly from on-chain — no filtering layer
+- Backend (be-quinty) has zero bounty/quest endpoints — it's purely auth + user profiles
+- Smart contracts have global `pause()` but no per-item moderation
+- No admin role exists anywhere in the system
+
+## What We're Building
+
+A full admin moderation system:
+
+1. **Backend moderation API** — endpoints to hide/unhide bounties and quests
+2. **Admin role** — hardcoded wallet addresses in env variable (simple, sufficient for early stage)
+3. **Frontend filtering** — hidden items don't appear on dashboard or detail pages
+4. **Admin panel page** — dedicated `/admin` page to manage hidden items and view stats
+5. **404 behavior** — hidden items return 404 when accessed via direct URL
+
+## Why This Approach
+
+**Backend-based moderation (not on-chain)** because:
+- No contract redeployment needed — current contracts don't have per-item hide
+- Faster iteration — can adjust moderation rules without gas costs
+- The on-chain data stays immutable (good for transparency), but display is controlled
+- Global `pause()` remains available for emergencies
+
+**Hardcoded wallet addresses** for admin because:
+- Simple — just env variable `ADMIN_WALLETS=0x...,0x...`
+- No DB migration for role column needed
+- Sufficient for current stage (small team)
+- Can upgrade to DB-based roles later
+
+**404 for hidden items** because:
+- Strictest approach — no info leak
+- Prevents accidental submissions to hidden bounties/quests
+- Clean from UX perspective
+
+## Key Decisions
+
+1. **Admin identity**: Hardcoded wallet addresses in `ADMIN_WALLETS` env var
+2. **Moderation storage**: New `moderated_items` table in Supabase (type, on_chain_id, reason, hidden_at, moderator_address)
+3. **Frontend data flow**: FE calls backend API to get list of hidden item IDs, then filters them out from on-chain reads
+4. **Detail page**: Hidden items show 404, not a "hidden" banner
+5. **Admin panel**: New `/admin` page — list all items, toggle hide/unhide, see stats
+6. **Scope**: Hide/unhide only — no on-chain cancel (would need contract changes)
+
+## Architecture
+
+```
+Frontend                    Backend                     On-chain
+  |                           |                            |
+  |-- GET /moderation/hidden -|-> Supabase moderated_items |
+  |                           |                            |
+  |-- useBounties() ----------|-------------------------> getBounty()
+  |-- useQuests() ------------|-------------------------> getQuest()
+  |                           |                            |
+  | (filter out hidden IDs    |                            |
+  |  from on-chain results)   |                            |
+  |                           |                            |
+  |-- POST /moderation/hide --|-> Insert moderated_items   |
+  |   (admin only)            |   (check ADMIN_WALLETS)    |
+```
+
+## Repos Affected
+
+- **be-quinty**: New moderation module (controller, service, entity), admin guard middleware
+- **fe-quinty**: Filter hidden items in useBounties/useQuests, 404 on detail pages, new /admin page
+- **sc-quinty**: No changes needed
+
+## Open Questions
+
+(none — all resolved during brainstorm)
+
+## Resolved Questions
+
+- **Who is admin?** → Hardcoded wallet addresses in env var
+- **What happens to hidden items?** → 404 on detail page, removed from dashboard
+- **On-chain cancel?** → Out of scope, backend-only hiding for now
+- **Prevent duplicates?** → Separate feature, lower priority — admin hide handles existing dupes

--- a/docs/plans/2026-03-07-feat-admin-moderation-plan.md
+++ b/docs/plans/2026-03-07-feat-admin-moderation-plan.md
@@ -1,0 +1,169 @@
+---
+title: "feat: Admin Moderation & Content Hiding"
+type: feat
+status: active
+date: 2026-03-07
+origin: docs/brainstorms/2026-03-07-admin-moderation-brainstorm.md
+---
+
+# Admin Moderation & Content Hiding
+
+## Overview
+
+Add a backend-based moderation system that lets admin wallets hide bounties/quests from the UI. Hidden items return 404 on detail pages and are filtered from dashboard listings. Includes a dedicated `/admin` page for managing moderation.
+
+(see brainstorm: `docs/brainstorms/2026-03-07-admin-moderation-brainstorm.md`)
+
+## Problem Statement
+
+Users can create duplicate or spam bounties/quests. There's currently no way to remove them — all data is read directly from on-chain with zero filtering.
+
+## Proposed Solution
+
+Backend moderation table in Supabase + API endpoints + frontend filtering. No smart contract changes needed.
+
+## Implementation Phases
+
+### Phase 1: Backend — Moderation Module (be-quinty)
+
+#### 1a. Supabase migration: `moderated_items` table
+
+```sql
+-- supabase migration
+CREATE TABLE moderated_items (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  item_type TEXT NOT NULL CHECK (item_type IN ('bounty', 'quest')),
+  on_chain_id INTEGER NOT NULL,
+  reason TEXT,
+  moderator_address TEXT NOT NULL,
+  hidden_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(item_type, on_chain_id)
+);
+
+CREATE INDEX idx_moderated_items_type ON moderated_items(item_type);
+```
+
+#### 1b. Admin guard middleware
+
+```
+be-quinty/src/common/guards/admin.guard.ts
+```
+
+- Read `ADMIN_WALLETS` from env (comma-separated wallet addresses)
+- Extract wallet address from JWT token (already in auth payload)
+- Compare against admin list
+- Return 403 if not admin
+
+#### 1c. Moderation module
+
+```
+be-quinty/src/moderation/
+  moderation.module.ts
+  moderation.controller.ts
+  moderation.service.ts
+  entities/moderated-item.entity.ts
+```
+
+**Endpoints:**
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/moderation/hidden` | Public | Returns `{bounties: number[], quests: number[]}` |
+| POST | `/moderation/hide` | Admin | Body: `{type, onChainId, reason}` |
+| DELETE | `/moderation/unhide/:type/:id` | Admin | Unhide an item |
+| GET | `/moderation/list` | Admin | Full list with reasons and timestamps |
+
+### Phase 2: Frontend — Filtering & 404 (fe-quinty)
+
+#### 2a. Hidden items hook
+
+```
+fe-quinty/src/hooks/useHiddenItems.ts
+```
+
+- Fetch `GET /moderation/hidden` on mount
+- Cache result, refresh every 60s
+- Export: `{ hiddenBountyIds: Set<number>, hiddenQuestIds: Set<number>, isHidden(type, id) }`
+
+#### 2b. Filter hidden items from listings
+
+**Files to modify:**
+- `src/hooks/useBounties.ts` — filter out hidden bounty IDs before returning
+- `src/hooks/useQuests.ts` — filter out hidden quest IDs before returning
+- `src/app/dashboard/page.tsx` — filter unified items using hidden IDs
+
+#### 2c. 404 on hidden detail pages
+
+**Files to modify:**
+- `src/app/bounties/[id]/page.tsx` — check `isHidden('bounty', id)`, show 404 if true
+- `src/app/quests/[id]/page.tsx` — check `isHidden('quest', id)`, show 404 if true
+
+Use Next.js `notFound()` from `next/navigation` to trigger the built-in 404 page.
+
+### Phase 3: Admin Panel (fe-quinty)
+
+#### 3a. Admin context/hook
+
+```
+fe-quinty/src/hooks/useAdmin.ts
+```
+
+- Check if current wallet address is in `NEXT_PUBLIC_ADMIN_WALLETS` env var
+- Export: `{ isAdmin: boolean }`
+
+#### 3b. Admin page
+
+```
+fe-quinty/src/app/admin/page.tsx
+```
+
+**Features:**
+- Gate: redirect non-admins to dashboard
+- List all bounties and quests (on-chain data) with hide/unhide toggles
+- Show hidden items highlighted with reason
+- Stats: total items, hidden items count, recent moderation actions
+- Search/filter by ID or title
+
+#### 3c. Admin nav link
+
+- Show "Admin" link in navbar only when `isAdmin` is true
+
+## Acceptance Criteria
+
+- [x] `moderated_items` table created in Supabase
+- [x] `ADMIN_WALLETS` env var configured in be-quinty
+- [x] `GET /moderation/hidden` returns list of hidden IDs (public, no auth)
+- [x] `POST /moderation/hide` requires admin wallet, creates record
+- [x] `DELETE /moderation/unhide/:type/:id` requires admin wallet, removes record
+- [x] Dashboard filters out hidden bounties and quests
+- [x] `bounties/:id` and `quests/:id` return 404 for hidden items
+- [x] `/admin` page accessible only to admin wallets
+- [x] Admin can hide/unhide from admin panel
+- [x] `NEXT_PUBLIC_ADMIN_WALLETS` env var configured in fe-quinty
+
+## Technical Considerations
+
+- **On-chain data persists**: Hiding is UI-only. On-chain submissions to hidden items are still possible (user would need to call contract directly). This is acceptable — the goal is preventing casual duplicate usage, not absolute enforcement.
+- **Caching**: Hidden items list is small and rarely changes. Cache in frontend with 60s refresh.
+- **Race condition**: If admin hides while user is on detail page, the user can still submit. Next page load will 404. Acceptable tradeoff.
+- **Backend downtime**: If backend is down, `useHiddenItems` returns empty set — all items show. Fail-open is acceptable since hiding is a moderation convenience, not security.
+
+## Dependencies
+
+- be-quinty must be running and accessible from fe-quinty
+- Supabase project must have migration applied
+- Both repos need new env vars
+
+## Sources & References
+
+### Origin
+
+- **Brainstorm document:** [docs/brainstorms/2026-03-07-admin-moderation-brainstorm.md](../brainstorms/2026-03-07-admin-moderation-brainstorm.md)
+  - Key decisions: hardcoded admin wallets, backend-only moderation, 404 for hidden items, no contract changes
+
+### Internal References
+
+- Auth guard pattern: `be-quinty/src/auth/auth.guard.ts`
+- Data fetching: `fe-quinty/src/hooks/useBounties.ts`, `fe-quinty/src/hooks/useQuests.ts`
+- Detail pages: `fe-quinty/src/app/bounties/[id]/page.tsx`, `fe-quinty/src/app/quests/[id]/page.tsx`
+- Dashboard: `fe-quinty/src/app/dashboard/page.tsx`

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import React, { useState, useEffect, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { useAccount } from "wagmi";
+import { readContract } from "@wagmi/core";
+import { useAdmin } from "../../hooks/useAdmin";
+import { useHiddenItems } from "../../hooks/useHiddenItems";
+import { useAuth } from "../../contexts/AuthContext";
+import { WalletName } from "../../components/WalletName";
+import { Button } from "../../components/ui/button";
+import { Input } from "../../components/ui/input";
+import {
+  CONTRACT_ADDRESSES,
+  QUINTY_ABI,
+  QUEST_ABI,
+  BASE_SEPOLIA_CHAIN_ID,
+} from "../../utils/contracts";
+import { wagmiConfig, formatAddress } from "../../utils/web3";
+import { fetchMetadataFromIpfs, BountyMetadata, QuestMetadata } from "../../utils/ipfs";
+import {
+  Shield,
+  Eye,
+  EyeOff,
+  Search,
+  Loader2,
+  Target,
+  Zap,
+  ChevronRight,
+} from "lucide-react";
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
+interface BountyItem {
+  id: number;
+  type: "bounty";
+  title: string;
+  creator: string;
+  status: number;
+  hidden: boolean;
+}
+
+interface QuestItem {
+  id: number;
+  type: "quest";
+  title: string;
+  creator: string;
+  resolved: boolean;
+  cancelled: boolean;
+  hidden: boolean;
+}
+
+type Item = BountyItem | QuestItem;
+
+export default function AdminPage() {
+  const router = useRouter();
+  const { address } = useAccount();
+  const { isAdmin } = useAdmin();
+  const { profile } = useAuth();
+  const { hiddenBountyIds, hiddenQuestIds, refetch: refetchHidden } = useHiddenItems();
+
+  const [items, setItems] = useState<Item[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [typeFilter, setTypeFilter] = useState<"all" | "bounties" | "quests">("all");
+  const [showHiddenOnly, setShowHiddenOnly] = useState(false);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isAdmin && !isLoading) {
+      router.push("/dashboard");
+    }
+  }, [isAdmin, isLoading, router]);
+
+  const loadItems = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const loadedItems: Item[] = [];
+
+      // Load bounties
+      try {
+        const bountyCounter = await readContract(wagmiConfig, {
+          address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quinty as `0x${string}`,
+          abi: QUINTY_ABI,
+          functionName: "bountyCounter",
+        });
+        const count = Number(bountyCounter);
+        for (let i = 1; i <= count; i++) {
+          try {
+            const data = await readContract(wagmiConfig, {
+              address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quinty as `0x${string}`,
+              abi: QUINTY_ABI,
+              functionName: "getBounty",
+              args: [BigInt(i)],
+            }) as any[];
+            let title = data[1] || `Bounty #${i}`;
+            const description = data[2] || "";
+            const metadataMatch = description.match(/Metadata: ipfs:\/\/([a-zA-Z0-9]+)/);
+            if (metadataMatch) {
+              try {
+                const meta = await fetchMetadataFromIpfs(metadataMatch[1]) as BountyMetadata;
+                if (meta.title) title = meta.title;
+              } catch {}
+            }
+            loadedItems.push({
+              id: i,
+              type: "bounty",
+              title,
+              creator: data[0],
+              status: Number(data[9]),
+              hidden: hiddenBountyIds.has(i),
+            });
+          } catch {}
+        }
+      } catch {}
+
+      // Load quests
+      try {
+        const questCounter = await readContract(wagmiConfig, {
+          address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quest as `0x${string}`,
+          abi: QUEST_ABI,
+          functionName: "questCounter",
+        });
+        const count = Number(questCounter);
+        for (let i = 1; i <= count; i++) {
+          try {
+            const data = await readContract(wagmiConfig, {
+              address: CONTRACT_ADDRESSES[BASE_SEPOLIA_CHAIN_ID].Quest as `0x${string}`,
+              abi: QUEST_ABI,
+              functionName: "getQuest",
+              args: [BigInt(i)],
+            }) as any[];
+            loadedItems.push({
+              id: i,
+              type: "quest",
+              title: data[1] || `Quest #${i}`,
+              creator: data[0],
+              resolved: data[10],
+              cancelled: data[11],
+              hidden: hiddenQuestIds.has(i),
+            });
+          } catch {}
+        }
+      } catch {}
+
+      setItems(loadedItems);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [hiddenBountyIds, hiddenQuestIds]);
+
+  useEffect(() => {
+    if (isAdmin) loadItems();
+  }, [isAdmin, loadItems]);
+
+  const toggleHide = async (item: Item) => {
+    const key = `${item.type}-${item.id}`;
+    setActionLoading(key);
+    try {
+      if (item.hidden) {
+        const res = await fetch(`${apiUrl}/moderation/unhide/${item.type}/${item.id}`, {
+          method: "DELETE",
+          credentials: "include",
+        });
+        if (!res.ok) throw new Error("Failed to unhide");
+      } else {
+        const res = await fetch(`${apiUrl}/moderation/hide`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({
+            type: item.type,
+            onChainId: item.id,
+            reason: "Hidden by admin",
+          }),
+        });
+        if (!res.ok) throw new Error("Failed to hide");
+      }
+      await refetchHidden();
+      // Update local state immediately
+      setItems((prev) =>
+        prev.map((i) =>
+          i.type === item.type && i.id === item.id ? { ...i, hidden: !i.hidden } : i
+        )
+      );
+    } catch (err) {
+      console.error("Moderation action failed:", err);
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const filteredItems = items.filter((item) => {
+    if (typeFilter === "bounties" && item.type !== "bounty") return false;
+    if (typeFilter === "quests" && item.type !== "quest") return false;
+    if (showHiddenOnly && !item.hidden) return false;
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      return (
+        item.title.toLowerCase().includes(q) ||
+        item.creator.toLowerCase().includes(q) ||
+        `${item.id}`.includes(q)
+      );
+    }
+    return true;
+  });
+
+  const hiddenCount = items.filter((i) => i.hidden).length;
+
+  if (!isAdmin) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-zinc-50">
+        <div className="text-center">
+          <Shield className="w-12 h-12 text-zinc-300 mx-auto mb-4" />
+          <p className="text-zinc-500 text-sm">Access denied</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-zinc-50 pt-20">
+      <div className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-zinc-900 flex items-center justify-center">
+              <Shield className="w-5 h-5 text-white" />
+            </div>
+            <div>
+              <h1 className="text-xl font-semibold text-zinc-900">Admin Moderation</h1>
+              <p className="text-xs text-zinc-400 mt-0.5">
+                {items.length} total items &middot; {hiddenCount} hidden
+              </p>
+            </div>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => { loadItems(); refetchHidden(); }}
+            disabled={isLoading}
+          >
+            {isLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : "Refresh"}
+          </Button>
+        </div>
+
+        {/* Filters */}
+        <div className="flex flex-wrap items-center gap-3 mb-6">
+          <div className="relative flex-1 max-w-xs">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-400" />
+            <Input
+              placeholder="Search by title, ID, or address..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="pl-9 h-10 text-sm"
+            />
+          </div>
+          <div className="flex items-center bg-white border border-zinc-200 p-0.5">
+            {(["all", "bounties", "quests"] as const).map((f) => (
+              <button
+                key={f}
+                onClick={() => setTypeFilter(f)}
+                className={`px-3 py-1.5 text-xs font-medium transition-all ${
+                  typeFilter === f
+                    ? "bg-zinc-900 text-white"
+                    : "text-zinc-500 hover:text-zinc-900"
+                }`}
+              >
+                {f === "all" ? "All" : f === "bounties" ? "Bounties" : "Quests"}
+              </button>
+            ))}
+          </div>
+          <button
+            onClick={() => setShowHiddenOnly(!showHiddenOnly)}
+            className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium border transition-all ${
+              showHiddenOnly
+                ? "bg-red-50 border-red-200 text-red-700"
+                : "bg-white border-zinc-200 text-zinc-500 hover:text-zinc-900"
+            }`}
+          >
+            <EyeOff className="w-3.5 h-3.5" />
+            Hidden only ({hiddenCount})
+          </button>
+        </div>
+
+        {/* Items list */}
+        {isLoading ? (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="w-6 h-6 animate-spin text-zinc-400" />
+          </div>
+        ) : filteredItems.length === 0 ? (
+          <div className="text-center py-20">
+            <p className="text-zinc-400 text-sm">No items found</p>
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {filteredItems.map((item) => {
+              const key = `${item.type}-${item.id}`;
+              const isToggling = actionLoading === key;
+              return (
+                <div
+                  key={key}
+                  className={`group flex items-center gap-4 px-4 py-3 bg-white border transition-all ${
+                    item.hidden
+                      ? "border-red-200 bg-red-50/50"
+                      : "border-zinc-200 hover:border-zinc-300"
+                  }`}
+                >
+                  {/* Type icon */}
+                  <div
+                    className={`w-8 h-8 flex items-center justify-center flex-shrink-0 ${
+                      item.type === "bounty" ? "bg-amber-50" : "bg-blue-50"
+                    }`}
+                  >
+                    {item.type === "bounty" ? (
+                      <Target className="w-4 h-4 text-amber-600" />
+                    ) : (
+                      <Zap className="w-4 h-4 text-blue-600" />
+                    )}
+                  </div>
+
+                  {/* Info */}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs font-mono text-zinc-400 uppercase">
+                        {item.type} #{item.id}
+                      </span>
+                      {item.hidden && (
+                        <span className="text-[10px] font-semibold text-red-600 bg-red-100 px-1.5 py-0.5">
+                          HIDDEN
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-sm font-medium text-zinc-900 truncate mt-0.5">
+                      {item.title}
+                    </p>
+                    <p className="text-xs text-zinc-400 mt-0.5">
+                      by <WalletName address={item.creator} />
+                    </p>
+                  </div>
+
+                  {/* Actions */}
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    <button
+                      onClick={() =>
+                        router.push(
+                          item.type === "bounty"
+                            ? `/bounties/${item.id}`
+                            : `/quests/${item.id}`
+                        )
+                      }
+                      className="h-8 px-3 text-xs font-medium text-zinc-500 hover:text-zinc-900 border border-zinc-200 hover:border-zinc-300 bg-white flex items-center gap-1 transition-all"
+                    >
+                      View <ChevronRight className="w-3 h-3" />
+                    </button>
+                    <button
+                      onClick={() => toggleHide(item)}
+                      disabled={isToggling}
+                      className={`h-8 px-3 text-xs font-medium flex items-center gap-1.5 transition-all ${
+                        item.hidden
+                          ? "bg-[#0EA885] text-white hover:bg-[#0c9478]"
+                          : "bg-red-500 text-white hover:bg-red-600"
+                      }`}
+                    >
+                      {isToggling ? (
+                        <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                      ) : item.hidden ? (
+                        <>
+                          <Eye className="w-3.5 h-3.5" /> Unhide
+                        </>
+                      ) : (
+                        <>
+                          <EyeOff className="w-3.5 h-3.5" /> Hide
+                        </>
+                      )}
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/bounties/[id]/page.tsx
+++ b/src/app/bounties/[id]/page.tsx
@@ -68,6 +68,7 @@ import {
   Layers,
 } from "lucide-react";
 import ethIcon from "../../../assets/crypto/eth.svg";
+import { useHiddenItems } from "../../../hooks/useHiddenItems";
 
 interface Submission {
   submitter: string;
@@ -109,6 +110,7 @@ export default function BountyDetailPage() {
   const { address } = useAccount();
   const { showAlert } = useAlert();
   const { profile } = useAuth();
+  const { isHidden } = useHiddenItems();
   const bountyId = params.id as string;
 
   const [bounty, setBounty] = useState<Bounty | null>(null);
@@ -356,7 +358,7 @@ export default function BountyDetailPage() {
     );
   }
 
-  if (!bounty) {
+  if (isHidden("bounty", parseInt(bountyId, 10)) || !bounty) {
     return (
       <div className="min-h-dvh flex items-center justify-center bg-stone-50">
         <div className="text-center">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -58,6 +58,7 @@ import {
   formatUSD,
 } from "../../utils/prices";
 import ethIcon from "../../assets/crypto/eth.svg";
+import { useHiddenItems } from "../../hooks/useHiddenItems";
 
 // === TYPES ===
 type FilterType = "all" | "live" | "in-review" | "completed" | "ended";
@@ -175,6 +176,7 @@ export default function DashboardPage() {
   const [submissionCounts, setSubmissionCounts] = useState<Map<string, number>>(new Map());
 
   const searchRef = useRef<HTMLInputElement>(null);
+  const { hiddenBountyIds, hiddenQuestIds } = useHiddenItems();
 
   // === EFFECTS ===
 
@@ -336,7 +338,10 @@ export default function DashboardPage() {
   // === COMPUTED ===
 
   const unifiedItems: UnifiedItem[] = useMemo(() => {
-    let combined = [...bounties, ...quests];
+    let combined: UnifiedItem[] = [
+      ...bounties.filter(b => !hiddenBountyIds.has(b.id)),
+      ...quests.filter(q => !hiddenQuestIds.has(q.id)),
+    ];
     if (typeFilter === "bounties") combined = combined.filter(i => i.type === "bounty");
     else if (typeFilter === "quests") combined = combined.filter(i => i.type === "quest");
 
@@ -386,7 +391,7 @@ export default function DashboardPage() {
       return b.id - a.id;
     });
     return combined;
-  }, [bounties, quests, activeFilter, typeFilter, categoryFilter, bountyMetadata, questMetadata, debouncedSearch, sortBy]);
+  }, [bounties, quests, activeFilter, typeFilter, categoryFilter, bountyMetadata, questMetadata, debouncedSearch, sortBy, hiddenBountyIds, hiddenQuestIds]);
 
   const displayedItems = useMemo(() => unifiedItems.slice(0, displayCount), [unifiedItems, displayCount]);
 

--- a/src/app/quests/[id]/page.tsx
+++ b/src/app/quests/[id]/page.tsx
@@ -57,6 +57,7 @@ import {
     Gavel,
 } from "lucide-react";
 import ethIcon from "../../../assets/crypto/eth.svg";
+import { useHiddenItems } from "../../../hooks/useHiddenItems";
 import { VerifierManagement } from "../../../components/quests/VerifierManagement";
 import { getPublicClient } from "@wagmi/core";
 
@@ -92,6 +93,7 @@ export default function QuestDetailPage() {
     const { address } = useAccount();
     const { showAlert } = useAlert();
     const { profile } = useAuth();
+    const { isHidden } = useHiddenItems();
     const questId = params.id as string;
 
     const [quest, setQuest] = useState<Quest | null>(null);
@@ -324,13 +326,13 @@ export default function QuestDetailPage() {
         );
     }
 
-    if (!quest) {
+    if (isHidden("quest", parseInt(questId, 10)) || !quest) {
         return (
             <div className="min-h-dvh flex items-center justify-center bg-stone-50">
                 <div className="text-center">
                     <h2 className="text-2xl font-bold mb-3">Quest not found</h2>
                     <p className="text-stone-500 mb-6 text-sm">The quest you're looking for doesn't exist.</p>
-                    <Button onClick={() => router.push("/quests")}>Back to Quests</Button>
+                    <Button onClick={() => router.push("/dashboard")}>Back to Dashboard</Button>
                 </div>
             </div>
         );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,6 +9,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { Menu, X } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useAccount } from "wagmi";
+import { useAdmin } from "@/hooks/useAdmin";
 import LoginButton from "./auth/LoginButton";
 import { WithdrawalBanner } from "./WithdrawalBanner";
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
@@ -20,6 +21,7 @@ export default function Header() {
   const pathname = usePathname();
   const { profile, loading } = useAuth();
   const { isConnected } = useAccount();
+  const { isAdmin } = useAdmin();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isMounted, setIsMounted] = useState(false);
   const [scrolled, setScrolled] = useState(false);
@@ -66,8 +68,8 @@ export default function Header() {
               </span>
             </button>
 
-            {/* Nav — just Dashboard */}
-            <nav className="hidden lg:flex items-center">
+            {/* Nav */}
+            <nav className="hidden lg:flex items-center gap-6">
               <Link
                 href="/dashboard"
                 className={cn(
@@ -79,6 +81,19 @@ export default function Header() {
               >
                 Dashboard
               </Link>
+              {isAdmin && (
+                <Link
+                  href="/admin"
+                  className={cn(
+                    "text-[13px] font-medium transition-colors duration-150",
+                    pathname === "/admin"
+                      ? "text-zinc-900"
+                      : "text-zinc-400 hover:text-zinc-600"
+                  )}
+                >
+                  Admin
+                </Link>
+              )}
             </nav>
           </div>
 
@@ -153,6 +168,18 @@ export default function Header() {
                 >
                   Profile
                 </Link>
+                {isAdmin && (
+                  <Link
+                    href="/admin"
+                    onClick={() => setIsMobileMenuOpen(false)}
+                    className={cn(
+                      "px-3 py-2.5 text-sm font-medium transition-colors",
+                      pathname === "/admin" ? "text-zinc-900" : "text-zinc-500 hover:text-zinc-900"
+                    )}
+                  >
+                    Admin
+                  </Link>
+                )}
                 {isMounted && !loading && !profile && (
                   <div className="mt-2 pt-2 border-t border-zinc-100 px-3">
                     <LoginButton />

--- a/src/hooks/useAdmin.ts
+++ b/src/hooks/useAdmin.ts
@@ -1,0 +1,17 @@
+import { useMemo } from "react";
+import { useAccount } from "wagmi";
+
+export function useAdmin() {
+  const { address } = useAccount();
+
+  const isAdmin = useMemo(() => {
+    if (!address) return false;
+    const adminWallets = (process.env.NEXT_PUBLIC_ADMIN_WALLETS || "")
+      .split(",")
+      .map((w) => w.trim().toLowerCase())
+      .filter(Boolean);
+    return adminWallets.includes(address.toLowerCase());
+  }, [address]);
+
+  return { isAdmin };
+}

--- a/src/hooks/useHiddenItems.ts
+++ b/src/hooks/useHiddenItems.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect, useCallback } from "react";
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
+interface HiddenItems {
+  bounties: number[];
+  quests: number[];
+}
+
+export function useHiddenItems() {
+  const [hiddenBountyIds, setHiddenBountyIds] = useState<Set<number>>(new Set());
+  const [hiddenQuestIds, setHiddenQuestIds] = useState<Set<number>>(new Set());
+
+  const fetchHidden = useCallback(async () => {
+    try {
+      const res = await fetch(`${apiUrl}/moderation/hidden`);
+      if (!res.ok) return;
+      const data: HiddenItems = await res.json();
+      setHiddenBountyIds(new Set(data.bounties));
+      setHiddenQuestIds(new Set(data.quests));
+    } catch {
+      // Fail open — if backend is down, show everything
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchHidden();
+    const interval = setInterval(fetchHidden, 60000);
+    return () => clearInterval(interval);
+  }, [fetchHidden]);
+
+  const isHidden = useCallback(
+    (type: "bounty" | "quest", id: number) => {
+      return type === "bounty" ? hiddenBountyIds.has(id) : hiddenQuestIds.has(id);
+    },
+    [hiddenBountyIds, hiddenQuestIds],
+  );
+
+  return { hiddenBountyIds, hiddenQuestIds, isHidden, refetch: fetchHidden };
+}


### PR DESCRIPTION
## Summary
- Add `/admin` page with hide/unhide toggles for all bounties & quests
- Filter hidden items from dashboard listings
- Show "not found" for hidden items on detail pages (`/bounties/:id`, `/quests/:id`)
- Add "Admin" nav link (only visible to admin wallets)
- New hooks: `useHiddenItems`, `useAdmin`

## Setup
Add to `.env.local`:
```
NEXT_PUBLIC_ADMIN_WALLETS=0x748a73c2befD2586F7aAdd6072718E0469B665D7
```

Requires be-quinty moderation endpoints to be running.

## Testing
- Connect admin wallet → see "Admin" in navbar
- Navigate to `/admin` → see all bounties/quests with hide/unhide buttons
- Hide an item → verify it disappears from dashboard
- Visit hidden item's detail page → see "not found"
- Connect non-admin wallet → no "Admin" link, `/admin` redirects to dashboard

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)