### PR TITLE
fix: add JWT auth header to admin moderation calls

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -157,17 +157,18 @@ export default function AdminPage() {
     const key = `${item.type}-${item.id}`;
     setActionLoading(key);
     try {
+      const token = localStorage.getItem('quinty_auth_token');
+      if (!token) throw new Error("Not authenticated");
       if (item.hidden) {
         const res = await fetch(`${apiUrl}/moderation/unhide/${item.type}/${item.id}`, {
           method: "DELETE",
-          credentials: "include",
+          headers: { Authorization: `Bearer ${token}` },
         });
         if (!res.ok) throw new Error("Failed to unhide");
       } else {
         const res = await fetch(`${apiUrl}/moderation/hide`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
-          credentials: "include",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
           body: JSON.stringify({
             type: item.type,
             onChainId: item.id,


### PR DESCRIPTION
## Summary
- Admin hide/unhide was sending `credentials: "include"` (cookies) instead of Bearer token
- Backend `JwtAuthGuard` expects `Authorization: Bearer <token>` header
- Added `localStorage.getItem('quinty_auth_token')` pattern (same as useSocialVerification)

## Test plan
- [ ] Click "Hide" on admin page — should succeed (no 404)
- [ ] Click "Unhide" on a hidden item — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)